### PR TITLE
Hotfix: lock SQLAlchemy to version 1.1.15

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -52,4 +52,5 @@ raven[flask]
 healthcheck
 elasticsearch
 flask-redis
+SQLAlchemy==1.1.15 # 1.2.0 doesn't work, check if any future versions work
 Flask-Elasticsearch


### PR DESCRIPTION
fixes #4585 
In version 1.2 of SQLAlchemy, Boolean datatype now enforces strict True/False/None values. This maybe caused factoryboy to break when inserting boolean values:
https://docs.sqlalchemy.org/en/latest/changelog/migration_12.html#change-4102

