### PR TITLE
Old style exceptions to new style exceptions

### DIFF
--- a/app/api/helpers/permission_manager.py
+++ b/app/api/helpers/permission_manager.py
@@ -359,7 +359,7 @@ def permission_manager(view, view_args, view_kwargs, *args, **kwargs):
     if 'event_identifier' in view_kwargs:
         try:
             event = Event.query.filter_by(identifier=view_kwargs['event_identifier']).one()
-        except NoResultFound, e:
+        except NoResultFound:
             return NotFoundError({'parameter': 'event_identifier'}, 'Event not found').respond()
         view_kwargs['event_id'] = event.id
 
@@ -367,7 +367,7 @@ def permission_manager(view, view_args, view_kwargs, *args, **kwargs):
     if 'identifier' in view_kwargs:
         try:
             event = Event.query.filter_by(identifier=view_kwargs['identifier']).one()
-        except NoResultFound, e:
+        except NoResultFound:
             return NotFoundError({'parameter': 'identifier'}, 'Event not found').respond()
         view_kwargs['id'] = event.id
 
@@ -409,7 +409,7 @@ def permission_manager(view, view_args, view_kwargs, *args, **kwargs):
                     continue
                 try:
                     data = mod.query.filter(getattr(mod, fetch_key_model) == view_kwargs[f_url]).one()
-                except NoResultFound, e:
+                except NoResultFound:
                     pass
                 else:
                     found = True


### PR DESCRIPTION
__e__ is not being used in these three instances.

<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes some Python 3 syntax errors.

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
- Python 3 syntax errors

#### Changes proposed in this pull request:
- Old style exceptions to new style exceptions


