### PR TITLE
Stop automatic deployment to gcloud

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,6 @@ script:
 after_success:
   - 'bash <(curl -s https://codecov.io/bash)'
   - bash scripts/push_api_docs.sh
-  - bash kubernetes/travis/deploy.sh
-  - bash kubernetes/travis/deploy-staging.sh
-  - bash kubernetes/travis/deploy-nextgen.sh
+  #- bash kubernetes/travis/deploy.sh
+  #- bash kubernetes/travis/deploy-staging.sh
+  #- bash kubernetes/travis/deploy-nextgen.sh


### PR DESCRIPTION
resolves #4605.
http://open-event-api-dev.herokuapp.com/ is live.
@mariobehling Please note that this will only stop the automatic deployment to api.eventyay.com.
This will not shutdown the app if it is running in gcloud, AFAIK that has to be done from the gcloud console. Although I see a 503 on visiting api.eventyay.com, so maybe it is already shut down explicitly, but someone with access to the gcloud console will have to double check just in case.