### PR TITLE
Fixes #4610: adding missing anchor tag in password reset link

### DIFF
--- a/app/api/helpers/system_mails.py
+++ b/app/api/helpers/system_mails.py
@@ -111,7 +111,7 @@ MAILS = {
         'recipient': 'User',
         'subject': u'{app_name}: Password Reset',
         'message': (
-            u"Please use the following link to reset your password.<br> {link}"
+            u"Please use the following link to reset your password.<br> <a href='{link}' target='_blank'>{link}</a>"
         )
     },
     PASSWORD_CHANGE: {


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4610 

#### Checklist

- [* ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [ *] My branch is up-to-date with the Upstream `development` branch.
- [ *] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ *] I have added tests that prove my fix is effective or that my feature works
- [ *] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ *] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Password reset link was not clickable because of the absence of an anchor tag.

#### Changes proposed in this pull request:

- Adding an anchor tag for password reset link
![screenshot before and after changes ](https://user-images.githubusercontent.com/13566432/36134978-1762b4a6-10ae-11e8-864b-a3c66a91f062.png)

