### PR TITLE
fix: Convert user id to int in feedbacks

### DIFF
--- a/app/api/feedbacks.py
+++ b/app/api/feedbacks.py
@@ -27,7 +27,7 @@ class FeedbackListPost(ResourceList):
         :return:
         """
         require_relationship(['event', 'user'], data)
-        if not has_access('is_user_itself', id=data['user']):
+        if not has_access('is_user_itself', id=int(data['user'])):
             raise ObjectNotFound({'parameter': 'user_id'},
                                  "User: {} doesn't match auth key".format(data['user']))
 


### PR DESCRIPTION
Fixes #4637 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:

Type mismatch between user ID in view data and database

#### Changes proposed in this pull request:

- Before comparison in permission_manager.py, user_id should be int
- The user id is data is string and warranted to be converted to right type

