### PR TITLE
Updates flask-rest-jsonapi to use the fossasia fork

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -43,7 +43,7 @@ pytz
 diff-match-patch
 blinker
 envparse
--e git+https://github.com/shubham-padia/flask-rest-jsonapi.git@master#egg=flask-rest-jsonapi
+-e git+https://github.com/fossasia/flask-rest-jsonapi.git@shubhamp-master#egg=flask-rest-jsonapi
 wtforms
 flask-admin
 google-compute-engine


### PR DESCRIPTION
Updates flask-rest-jsonapi to use the fossasia fork than the one by @shubham-padia . I have fetched and pushed @shubham-padia's branch to the fork and am using that. Check it here: https://github.com/fossasia/flask-rest-jsonapi/tree/shubhamp-master

**Benefits:** Since it is dependent on the organization's fork, the developer doesn't have to worry if someday he needs to delete it. Also, people find it easier to trust the organization's fork (since org is then responsible) than the developer's fork