### PR TITLE
Fix README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 ![Open Event Server](https://storage.googleapis.com/eventyay.com/assets/branding/server_branding.png)
 
 [![GitHub release](https://img.shields.io/badge/release-1.0.0--alpha.10-blue.svg?style=flat-square)](https://github.com/fossasia/open-event-server/releases/latest)
-[![Travis branch](https://img.shields.io/travis/fossasia/open-event-server/master.svg?style=flat-square)](https://travis-ci.org/fossasia/open-event-server)
-[![Gemnasium](https://img.shields.io/gemnasium/fossasia/open-event-server.svg?style=flat-square)](https://gemnasium.com/github.com/fossasia/open-event-server)
-[![Codacy branch grade](https://img.shields.io/codacy/grade/1ac554483fac462797ffa5a8b9adf2fa/master.svg?style=flat-square)](https://www.codacy.com/app/fossasia/open-event-orga-server)
-[![Codecov branch](https://img.shields.io/codecov/c/github/fossasia/open-event-orga-server/master.svg?style=flat-square&label=Codecov+Coverage)](https://codecov.io/gh/fossasia/open-event-orga-server)
+[![Travis branch](https://api.travis-ci.org/fossasia/open-event-server.svg?branch=master&style=flat-square)](https://travis-ci.org/fossasia/open-event-server)
+[![Gemnasium](https://gemnasium.com/fossasia/open-event-server.svg?style=flat-square)](https://gemnasium.com/github.com/fossasia/open-event-server)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/1ac554483fac462797ffa5a8b9adf2fa?style=flat-square)](https://www.codacy.com/app/fossasia/open-event-orga-server)
+[![Codecov branch](https://codecov.io/gh/fossasia/open-event-server/branch/master/graph/badge.svg?style=flat-square)](https://codecov.io/gh/fossasia/open-event-orga-server)
 [![Gitter](https://img.shields.io/badge/chat-on%20gitter-ff006f.svg?style=flat-square)](https://gitter.im/fossasia/open-event-server)
 [![Open Source Helpers](https://www.codetriage.com/fossasia/open-event-orga-server/badges/users.svg)](https://www.codetriage.com/fossasia/open-event-orga-server)
 


### PR DESCRIPTION
Fixes #4657.

#### Checklist

- [ x ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [ x ] My branch is up-to-date with the Upstream `development` branch.
- [ x ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] I have added necessary documentation (if appropriate)
- [ x ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
shields.io currently faces large latency for Travis, Gemnasium, Codacy and Codecov statuses. As a result, these badges are not rendered on the README due to timeouts. This PR changes README markdown to fetch the badges from the respective services' APIs instead of shields.io so that the badges get rendered quickly and properly - this also ensures the rendering of the badges so that we're on the safer side.

#### Changes proposed in this pull request:

- Change README image links for 4 badges mentioned above.
