### PR TITLE
fix: Raise HTTP 409 on Create Ticket with Duplicate Name

### DIFF
--- a/app/api/tickets.py
+++ b/app/api/tickets.py
@@ -12,6 +12,8 @@ from app.models.access_code import AccessCode
 from app.models.order import Order
 from app.models.ticket import Ticket, TicketTag, ticket_tags_table
 from app.models.ticket_holder import TicketHolder
+from app.api.helpers.exceptions import ConflictException
+from app.api.helpers.db import get_count
 
 
 class TicketListPost(ResourceList):
@@ -30,6 +32,9 @@ class TicketListPost(ResourceList):
         if not has_access('is_coorganizer', event_id=data['event']):
             raise ObjectNotFound({'parameter': 'event_id'},
                                  "Event: {} not found".format(data['event_id']))
+
+        if get_count(db.session.query(Ticket.id).filter_by(name=data['name'], event_id=int(data['event']))) > 0:
+            raise ConflictException({'pointer': '/data/attributes/name'}, "Ticket already exists")
 
     schema = TicketSchema
     methods = ['POST', ]


### PR DESCRIPTION
Fixes #4672 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
When a user tries to create ticket with same name as some other ticket for the same event then ConflictException is raised instead of HTTP 500.

#### Changes proposed in this pull request:

- Raise ConflictException on duplicate Ticket name.


@iamareebjamal @shubham-padia @poush Please review.
