### PR TITLE
fix: Add defaults field values before validating schema

### DIFF
--- a/app/api/schema/custom_forms.py
+++ b/app/api/schema/custom_forms.py
@@ -3,8 +3,10 @@ from marshmallow_jsonapi import fields
 from marshmallow_jsonapi.flask import Schema, Relationship
 
 from app.api.helpers.utilities import dasherize
+from utils.common import use_defaults
 
 
+@use_defaults()
 class CustomFormSchema(Schema):
     """
     API Schema for Custom Forms database model

--- a/app/api/schema/email_notifications.py
+++ b/app/api/schema/email_notifications.py
@@ -2,8 +2,10 @@ from marshmallow_jsonapi import fields
 from marshmallow_jsonapi.flask import Schema, Relationship
 
 from app.api.helpers.utilities import dasherize
+from utils.common import use_defaults
 
 
+@use_defaults()
 class EmailNotificationSchema(Schema):
     """
     API Schema for email notification Model

--- a/app/api/schema/event_invoices.py
+++ b/app/api/schema/event_invoices.py
@@ -4,8 +4,10 @@ from marshmallow_jsonapi.flask import Schema, Relationship
 
 from app.api.helpers.static import PAYMENT_COUNTRIES
 from app.api.helpers.utilities import dasherize
+from utils.common import use_defaults
 
 
+@use_defaults()
 class EventInvoiceSchema(Schema):
     """
     Event Invoice API Schema based on event invoice model

--- a/app/api/schema/events.py
+++ b/app/api/schema/events.py
@@ -9,8 +9,10 @@ from flask_rest_jsonapi.exceptions import ObjectNotFound
 from app.models.event import Event
 from app.api.helpers.exceptions import UnprocessableEntity
 from app.api.helpers.utilities import dasherize
+from utils.common import use_defaults
 
 
+@use_defaults()
 class EventSchemaPublic(Schema):
     class Meta:
         type_ = 'event'

--- a/app/api/schema/image_sizes.py
+++ b/app/api/schema/image_sizes.py
@@ -2,8 +2,10 @@ from marshmallow_jsonapi import fields
 from marshmallow_jsonapi.flask import Schema
 
 from app.api.helpers.utilities import dasherize
+from utils.common import use_defaults
 
 
+@use_defaults()
 class ImageSizeSchema(Schema):
     """
     Api schema for image_size Model

--- a/app/api/schema/modules.py
+++ b/app/api/schema/modules.py
@@ -2,8 +2,10 @@ from marshmallow_jsonapi import fields
 from marshmallow_jsonapi.flask import Schema
 
 from app.api.helpers.utilities import dasherize
+from utils.common import use_defaults
 
 
+@use_defaults()
 class ModuleSchema(Schema):
     """
     Admin Api schema for modules Model

--- a/app/api/schema/orders.py
+++ b/app/api/schema/orders.py
@@ -7,8 +7,10 @@ from app import db
 from app.api.helpers.payment import PayPalPaymentsManager
 from app.api.helpers.utilities import dasherize
 from app.models.order import Order
+from utils.common import use_defaults
 
 
+@use_defaults()
 class OrderSchema(Schema):
     class Meta:
         type_ = 'order'

--- a/app/api/schema/pages.py
+++ b/app/api/schema/pages.py
@@ -3,8 +3,10 @@ from marshmallow_jsonapi import fields
 from marshmallow_jsonapi.flask import Schema
 
 from app.api.helpers.utilities import dasherize
+from utils.common import use_defaults
 
 
+@use_defaults()
 class PageSchema(Schema):
     """
     Api schema for page Model

--- a/app/api/schema/role_invites.py
+++ b/app/api/schema/role_invites.py
@@ -8,8 +8,10 @@ from app.models.role_invite import RoleInvite
 from app.api.helpers.exceptions import UnprocessableEntity
 from app.api.helpers.utilities import dasherize
 from app.models.role import Role
+from utils.common import use_defaults
 
 
+@use_defaults()
 class RoleInviteSchema(Schema):
     """
     Api Schema for role invite model

--- a/app/api/schema/sessions.py
+++ b/app/api/schema/sessions.py
@@ -6,8 +6,10 @@ from app.api.helpers.exceptions import UnprocessableEntity, ForbiddenException
 from app.api.helpers.permission_manager import has_access
 from app.api.helpers.utilities import dasherize
 from app.models.session import Session
+from utils.common import use_defaults
 
 
+@use_defaults()
 class SessionSchema(Schema):
     """
     Api schema for Session Model

--- a/app/api/schema/settings.py
+++ b/app/api/schema/settings.py
@@ -3,8 +3,10 @@ from marshmallow_jsonapi.flask import Schema
 
 from app.api.helpers.utilities import dasherize
 from app.settings import Environment
+from utils.common import use_defaults
 
 
+@use_defaults()
 class SettingSchemaAdmin(Schema):
     """
     Admin Api schema for settings Model

--- a/app/api/schema/speakers.py
+++ b/app/api/schema/speakers.py
@@ -2,8 +2,10 @@ from marshmallow_jsonapi import fields
 from marshmallow_jsonapi.flask import Schema, Relationship
 
 from app.api.helpers.utilities import dasherize
+from utils.common import use_defaults
 
 
+@use_defaults()
 class SpeakerSchema(Schema):
     """
     Speaker Schema based on Speaker Model

--- a/app/api/schema/tax.py
+++ b/app/api/schema/tax.py
@@ -2,8 +2,10 @@ from marshmallow_jsonapi import fields
 from marshmallow_jsonapi.flask import Schema, Relationship
 
 from app.api.helpers.utilities import dasherize
+from utils.common import use_defaults
 
 
+@use_defaults()
 class TaxSchemaPublic(Schema):
     class Meta:
         type_ = 'tax'

--- a/app/api/schema/tickets.py
+++ b/app/api/schema/tickets.py
@@ -5,8 +5,10 @@ from marshmallow_jsonapi.flask import Schema, Relationship
 from app.api.helpers.exceptions import UnprocessableEntity
 from app.api.helpers.utilities import dasherize
 from app.models.ticket import Ticket
+from utils.common import use_defaults
 
 
+@use_defaults()
 class TicketSchemaPublic(Schema):
     class Meta:
         type_ = 'ticket'

--- a/tests/unittests/utils/test_schema_defaulting.py
+++ b/tests/unittests/utils/test_schema_defaulting.py
@@ -1,0 +1,50 @@
+import unittest
+
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema
+
+from app import current_app as app
+from app.api.helpers.utilities import dasherize
+from utils.common import patch_defaults
+
+
+class TestSchema(Schema):
+    """
+    Api schema for Testing Purposes
+    """
+
+    class Meta:
+        """
+        Meta class for the test Schema
+        """
+        type_ = 'test-schema'
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    field_without_default = fields.Str(required=True)
+    field_with_default = fields.Boolean(required=True, default=False)
+
+
+class TestUtils:
+
+    def test_patch_defaults_adds_defaults(self):
+        with app.test_request_context():
+            schema = TestSchema()
+            data = {
+                'field_without_default': 'value_field_without_default'
+            }
+            patched_data = patch_defaults(schema, data)
+            self.assertEqual(patched_data.get('field_with_default'), False)
+
+    def test_patch_defaults_leaves_other_fields_untouched(self):
+        with app.test_request_context():
+            schema = TestSchema()
+            data = {
+                'field_without_default': 'value_field_without_default'
+            }
+            patched_data = patch_defaults(schema, data)
+            self.assertEqual(patched_data.get('field_without_default'), 'value_field_without_default')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils/common.py
+++ b/utils/common.py
@@ -1,0 +1,41 @@
+from marshmallow import pre_load
+
+from app.api.helpers.utilities import dasherize
+
+
+def patch_defaults(schema, in_data):
+    """
+    Add default values to None fields
+    :param schema: Schema
+    :param in_data: the json data comprising of the fields
+    :return: json data with default values
+    """
+    for name, field in schema.fields.items():
+        dasherized_name = dasherize(name)
+        attribute = in_data.get(dasherized_name)
+        if attribute is None:
+            in_data[dasherized_name] = field.default
+    return in_data
+
+
+@pre_load
+def make_object(schema, in_data):
+    """
+    Returns the json data after adding defaults
+    :param schema: Schema
+    :param in_data: the json data comprising of the fields
+    :return: json data returned by the patch_default function
+    """
+    return patch_defaults(schema, in_data)
+
+
+def use_defaults():
+    """
+    Decorator added to model classes which have default values specified for one of it's fields
+    Adds the make_object method defined above to the class.
+    :return: wrapper
+    """
+    def wrapper(k, *args, **kwargs):
+        setattr(k, "make_object", eval("make_object", *args, **kwargs))
+        return k
+    return wrapper


### PR DESCRIPTION
Fixes #4655 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Fixes the wrong schema validation. Default values are now added to the data before deserializing it.

#### Changes proposed in this pull request:

- Add default values to the fields before schema validation

**TODO**:

- [x] Add the decorator to all the schema classes
- [x] Write a few tests
- [x] Add necessary docstrings

~~~@iamareebjamal I have opened the WIP PR so as to get feedback on the way the decorator has been implemented. Is it fine ? Moreover suggestions of the name of the decorator is also welcomed.~~~
