### PR TITLE
fix: update kubernetes deployment documentation

### DIFF
--- a/docs/installation/gce-kubernetes.md
+++ b/docs/installation/gce-kubernetes.md
@@ -90,7 +90,7 @@ _You can delete the instance if your not planning to use it for anything else. B
 - Create a cluster via the `gcloud` command line tool:
 
     ```
-    gcloud container clusters create opev-cluster --cluster-version=1.6.4
+    gcloud container clusters create opev-cluster
     ```
 
 - Get the credentials for `kubectl` to use.
@@ -110,22 +110,20 @@ _You can delete the instance if your not planning to use it for anything else. B
 	The response would be similar to
 
 	```
-	address: 123.123.123.123
-	creationTimestamp: '2017-05-16T05:26:24.894-07:00'
-	description: ''
-	id: '1234556789'
-	kind: compute#address
-	name: test
-	selfLink: https://www.googleapis.com/compute/v1/projects/eventyay/global/addresses/test
-	status: RESERVED
+	Created [https://www.googleapis.com/compute/v1/projects/eventyay-212514/regions/us-west1/addresses/testip].
+	```
+- Listing static external IP addresses
+
+    ```bash
+	gcloud compute addresses list --filter=testip
 	```
 
-	Note down the address. (In this case `123.123.123.123`). We'll call this **External IP Address One**.
+	Note down the address. We'll call this **External IP Address One**.
 - Add the **External IP Address One** as an `A` record to your domain's DNS Zone.
 - Add the **External IP Address One** to `kubernetes/yamls/nginx/service.yml` for the parameter `loadBalancerIP`.
 - Add your domain name to `kubernetes/yamls/web/ingress-notls.yml` & `kubernetes/yamls/web/ingress-tls.yml`. (replace `api.eventyay.com`)
 - Add your email ID to `kubernetes/yamls/lego/configmap.yml` for the parameter `lego.email`.
-- In `kubernetes/yamls/postgres/postgres-pod.yml` ensure `pdName` is `pg-data-disk`. Else change it.
+- In `kubernetes/yamls/postgres/deployment.yml` ensure `pdName` is `pg-data-disk`. Else change it.
 
 ## Deploy our pods, services and deployments
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4684 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Removed `gcloud container clusters create opev-cluster --cluster-version=1.6.4`
because it was returning the error 
ERROR: (gcloud.container.clusters.create) ResponseError: code=400, message=no valid versions with the prefix "1.6.4" found.
and made appropriate changes to correct the documentation

#### Changes proposed in this pull request:
update kubernetes deployment documentation



