### PR TITLE
Fixes #4692 Key error: 'user_id' when logging in the server

### DIFF
--- a/app/api/helpers/permission_manager.py
+++ b/app/api/helpers/permission_manager.py
@@ -106,7 +106,7 @@ def is_user_itself(view, view_args, view_kwargs, *args, **kwargs):
     Otherwise the user can only access his/her resource.
     """
     user = current_identity
-    if not user.is_admin and not user.is_super_admin and user.id != kwargs['user_id']:
+    if not user.is_admin and not user.is_super_admin and user.id != kwargs['id']:
         return ForbiddenError({'source': ''}, 'Access Forbidden').respond()
     return view(*view_args, **view_kwargs)
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4692 Key error: 'user_id' when logging in the server

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:

Changing user_id to id in function `is_user_itself` at https://github.com/fossasia/open-event-server/blob/development/app/api/helpers/permission_manager.py#L109

#### Changes proposed in this pull request:

- Changing user_id to id in function `is_user_itself` at https://github.com/fossasia/open-event-server/blob/development/app/api/helpers/permission_manager.py#L109

@iamareebjamal @poush @srv-twry please review thanks.


