### PR TITLE
Remove JWT Key requirement for registering a user

### DIFF
--- a/docs/api/api_blueprint.apib
+++ b/docs/api/api_blueprint.apib
@@ -194,8 +194,6 @@ Create a new user using an email, password and an optional name.
 
     + Headers
 
-            Authorization: JWT <Auth Key>
-
     + Body
 
             {


### PR DESCRIPTION
Fixes #4686

- I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- My branch is up-to-date with the Upstream `development` branch.
- I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
The current API documentation mentions that creating a user (i.e., registering one) requires the use of a JWT key for authorization, which is false. This confuses new users / contributors and can lead them to think they're in a deadlock, as acquiring a key mandates the user to be registered with our service!

#### Changes proposed in this pull request:
- Fix API documentation for creating a user


