### PR TITLE
fix: HTTP 500 on fetching notifications by converting id to user_id

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -93,7 +93,7 @@ api.route(NotificationRelationship, 'notification_user',
 
 # email_notifications
 api.route(EmailNotificationListAdmin, 'email_notification_list_admin', '/email-notifications')
-api.route(EmailNotificationList, 'email_notification_list', '/users/<int:id>/email-notifications')
+api.route(EmailNotificationList, 'email_notification_list', '/users/<int:user_id>/email-notifications')
 api.route(EmailNotificationDetail, 'email_notification_detail', '/email-notifications/<int:id>')
 api.route(EmailNotificationRelationshipRequired, 'email_notification_user',
           '/email-notifications/<int:id>/relationships/user')

--- a/app/api/email_notifications.py
+++ b/app/api/email_notifications.py
@@ -32,14 +32,14 @@ class EmailNotificationList(ResourceList):
         :return:
         """
         query_ = self.session.query(EmailNotification)
-        if view_kwargs.get('id'):
-            user = safe_query(self, User, 'id', view_kwargs['id'], 'id')
+        if view_kwargs.get('user_id'):
+            user = safe_query(self, User, 'id', view_kwargs['user_id'], 'user_id')
             query_ = query_.join(User).filter(User.id == user.id)
         return query_
 
     view_kwargs = True
     methods = ['GET', ]
-    decorators = (api.has_permission('is_user_itself', fetch="id", fetch_as="id"),)
+    decorators = (api.has_permission('is_user_itself', fetch="user_id", model=EmailNotification),)
     schema = EmailNotificationSchema
     data_layer = {'session': db.session,
                   'model': EmailNotification,
@@ -52,8 +52,7 @@ class EmailNotificationDetail(ResourceDetail):
     """
     Email notification detail by ID
     """
-    decorators = (api.has_permission('is_user_itself', fetch="user_id", fetch_as="id",
-                  model=EmailNotification),)
+    decorators = (api.has_permission('is_user_itself', fetch="user_id", model=EmailNotification),)
     schema = EmailNotificationSchema
     data_layer = {'session': db.session,
                   'model': EmailNotification}
@@ -74,8 +73,7 @@ class EmailNotificationRelationshipOptional(ResourceRelationship):
     """
     Email notification Relationship (Optional)
     """
-    decorators = (api.has_permission('is_user_itself', fetch="user_id", fetch_as="id",
-                                     model=EmailNotification),)
+    decorators = (api.has_permission('is_user_itself', fetch="user_id", model=EmailNotification),)
     schema = EmailNotificationSchema
     data_layer = {'session': db.session,
                   'model': EmailNotification}

--- a/app/api/helpers/permission_manager.py
+++ b/app/api/helpers/permission_manager.py
@@ -348,12 +348,6 @@ def permission_manager(view, view_args, view_kwargs, *args, **kwargs):
         if not check(view_kwargs):
             return ForbiddenError({'source': ''}, 'Access forbidden').respond()
 
-    # leave_if checks if we have to bypass this request on the basis of lambda function
-    if 'leave_if' in kwargs:
-        check = kwargs['leave_if']
-        if check(view_kwargs):
-            return view(*view_args, **view_kwargs)
-
     # If event_identifier in route instead of event_id
     if 'event_identifier' in view_kwargs:
         try:
@@ -383,7 +377,6 @@ def permission_manager(view, view_args, view_kwargs, *args, **kwargs):
         if not fetched:
             model = kwargs['model']
             fetch = kwargs['fetch']
-            fetch_as = kwargs['fetch_as']
             fetch_key_url = 'id'
             fetch_key_model = 'id'
             if 'fetch_key_url' in kwargs:
@@ -427,7 +420,10 @@ def permission_manager(view, view_args, view_kwargs, *args, **kwargs):
                 fetched = getattr(data, fetch) if hasattr(data, fetch) else None
 
         if fetched:
-            kwargs[kwargs['fetch_as']] = fetched
+            if 'fetch_as' in kwargs:
+                kwargs[kwargs['fetch_as']] = fetched
+            elif 'fetch' in kwargs:
+                kwargs[kwargs['fetch']] = fetched
         else:
             return NotFoundError({'source': ''}, 'Object not found.').respond()
 

--- a/app/api/notifications.py
+++ b/app/api/notifications.py
@@ -48,7 +48,7 @@ class NotificationList(ResourceList):
             data['user_id'] = user.id
 
     view_kwargs = True
-    decorators = (api.has_permission('is_user_itself', fetch="user_id", fetch_as="id", model=Notification),)
+    decorators = (api.has_permission('is_user_itself', fetch="user_id", model=Notification),)
     methods = ['GET']
     schema = NotificationSchema
     data_layer = {'session': db.session,
@@ -63,7 +63,7 @@ class NotificationDetail(ResourceDetail):
     """
     Notification detail by ID
     """
-    decorators = (api.has_permission('is_user_itself', fetch="user_id", fetch_as="id", model=Notification),)
+    decorators = (api.has_permission('is_user_itself', fetch="user_id", model=Notification),)
     schema = NotificationSchema
     data_layer = {'session': db.session,
                   'model': Notification}
@@ -73,7 +73,7 @@ class NotificationRelationship(ResourceRelationship):
     """
     Notification Relationship
     """
-    decorators = (api.has_permission('is_user_itself', fetch="user_id", fetch_as="id", model=Notification),)
+    decorators = (api.has_permission('is_user_itself', fetch="user_id", model=Notification),)
     schema = NotificationSchema
     methods = ['GET', 'PATCH']
     data_layer = {'session': db.session,

--- a/app/api/schema/users.py
+++ b/app/api/schema/users.py
@@ -112,7 +112,7 @@ class UserSchema(UserSchemaPublic):
         self_view='v1.user_email_notifications',
         self_view_kwargs={'id': '<id>'},
         related_view='v1.email_notification_list',
-        related_view_kwargs={'id': '<id>'},
+        related_view_kwargs={'user_id': '<id>'},
         schema='EmailNotificationSchema',
         many=True,
         type_='email-notification')


### PR DESCRIPTION
Fixes #4722 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Server errors out when getting the user notifications and sends HTTP 500. This PR resolves the error


#### Changes proposed in this pull request:
Straightforward change from ```id``` to ```user_id```


