### PR TITLE
Fixes #4739 Google Installation guide still uses python2

### DIFF
--- a/docs/installation/aws.md
+++ b/docs/installation/aws.md
@@ -56,7 +56,7 @@ sudo apt-get install -y docker-engine
 * Then install Docker Compose.
 
 ```sh
-sudo apt-get -y install python-pip
+sudo apt-get -y install python3-pip
 sudo pip install docker-compose
 ```
 
@@ -123,9 +123,9 @@ docker-compose run web /bin/bash
 * When bash opens, run the following commands and exit.
 
 ```bash
-python create_db.py
+python3 create_db.py
 # ^^ write super_admin email and password when asked
-python manage.py db stamp head
+python3 manage.py db stamp head
 ```
 
 * That's it. Visit the public DNS to see your site live. In my case it was http://ec2-52-41-207-116.us-west-2.compute.amazonaws.com/

--- a/docs/installation/basic.md
+++ b/docs/installation/basic.md
@@ -16,7 +16,7 @@ Make sure you have the dependencies mentioned above installed before proceeding 
 Run the commands mentioned below with the terminal active in the project's root directory.
 
 
-* **Step 1** - Install python requirements.
+* **Step 1** - Install Python 3 requirements.
 
 ```sh
 pip3 install -r requirements.txt

--- a/docs/installation/digital-ocean.md
+++ b/docs/installation/digital-ocean.md
@@ -47,7 +47,7 @@ sudo systemctl status docker
 * Next step is to install Docker-Compose. Following the [DigitalOcean guide](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-compose-on-ubuntu-14-04), run the following commands in the ssh shell to install compose.
 
 ```bash
-sudo apt-get -y install python-pip
+sudo apt-get -y install python3-pip
 sudo pip install docker-compose
 ```
 
@@ -95,9 +95,9 @@ docker-compose run web /bin/bash
 * When bash opens, run the following commands and exit.
 
 ```bash
-python create_db.py
+python3 create_db.py
 # ^^ write super_admin email and password when asked
-python manage.py db stamp head
+python3 manage.py db stamp head
 ```
 
 * That's it. Visit the `$IP` (example 104.236.228.132) to view the open event server. You can close the 2nd terminal window if you wish.

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -43,9 +43,9 @@ create database opev;
 * Now the database is created, so let's create the tables. Open the application's shell by `docker-compose run web /bin/bash`. Then write the following commands.
 
 ```bash
-python create_db.py
+python3 create_db.py
 # ^^ write super_admin email and password when asked
-python manage.py db stamp head
+python3 manage.py db stamp head
 ```
 
 * Close the application's shell by `exit` command.
@@ -62,7 +62,7 @@ python manage.py db stamp head
 * Then open a new terminal window in same directory and run the following.
 
 ```bash
-docker-compose run web python manage.py db upgrade
+docker-compose run web python3 manage.py db upgrade
 ```
 
 * That should be all. Open `localhost` in web browser to view the updated open-event-server.

--- a/docs/installation/google.md
+++ b/docs/installation/google.md
@@ -111,7 +111,7 @@ lines 1-19/19 (END)
 
 * For the Next Step we'll setup Docker Compose.
 ```sh
-sudo apt-get -y install python-pip
+sudo apt-get -y install python3-pip
 sudo pip install docker-compose
 ```
 
@@ -146,9 +146,9 @@ sudo docker-compose run web /bin/bash
 
 * Once you are running bash in your container as root,
 ```sh
-python create_db.py
+python3 create_db.py
 # The Email & Password entered here would be your Admin Email
-python manage.py db stamp head
+python3 manage.py db stamp head
 ```
 
 * Now that db is setup, you can kill both the running containers by ^C, and then run
@@ -164,17 +164,17 @@ sudo docker-compose up -d
 ```
 Exception:
 Traceback (most recent call last):
-  File "/usr/lib/python2.7/dist-packages/pip/basecommand.py", line 209, in main
+  File "/usr/lib/python3.5/dist-packages/pip/basecommand.py", line 209, in main
     status = self.run(options, args)
-  File "/usr/lib/python2.7/dist-packages/pip/commands/install.py", line 317, in run
+  File "/usr/lib/python3.5/dist-packages/pip/commands/install.py", line 317, in run
     requirement_set.prepare_files(finder)
-  File "/usr/lib/python2.7/dist-packages/pip/req/req_set.py", line 360, in prepare_files
+  File "/usr/lib/python3.5/dist-packages/pip/req/req_set.py", line 360, in prepare_files
     ignore_dependencies=self.ignore_dependencies))
-  File "/usr/lib/python2.7/dist-packages/pip/req/req_set.py", line 448, in _prepare_file
+  File "/usr/lib/python3.5/dist-packages/pip/req/req_set.py", line 448, in _prepare_file
     req_to_install, finder)
-  File "/usr/lib/python2.7/dist-packages/pip/req/req_set.py", line 387, in _check_skip_installed
+  File "/usr/lib/python3.5/dist-packages/pip/req/req_set.py", line 387, in _check_skip_installed
     req_to_install.check_if_exists()
-  File "/usr/lib/python2.7/dist-packages/pip/req/req_install.py", line 1011, in check_if_exists
+  File "/usr/lib/python3.5/dist-packages/pip/req/req_install.py", line 1011, in check_if_exists
     self.req.project_name
 AttributeError: 'Requirement' object has no attribute 'project_name'
 ```

--- a/docs/installation/local.md
+++ b/docs/installation/local.md
@@ -148,7 +148,7 @@ export INTEGRATE_SOCKETIO="true"
 
 The development server is the one that Flask ships with. It's based on Werkzeug and does not support WebSockets. If you try to run it, you'll get a RunTime error, something like: `You need to use the eventlet server. `.  To test real-time notifications, you must use the Gunicorn web server with eventlet worker class.
 
-If you've installed development requirements, you should have both `gunicorn` and `eventlet` installed. To run application on port 5000, execute the following instead of `python manage.py runserver`:
+If you've installed development requirements, you should have both `gunicorn` and `eventlet` installed. To run application on port 5000, execute the following instead of `python3 manage.py runserver`:
 
 ```bash
 gunicorn app:app --worker-class eventlet -w 1 --bind 0.0.0.0:5000 --reload

--- a/docs/installation/mac-os.md
+++ b/docs/installation/mac-os.md
@@ -2,7 +2,7 @@
 
 ## Dependencies required to run Orga Server
 
-* Python 2
+* Python 3
 
 * Installation of 'Homebrew' would catalyze the process of installation
 ```sh
@@ -33,15 +33,15 @@ You may encounter problems installing 'libevent' while executing the requirement
 Installing the below files would prevent the 'egg_info' error.
 
 ```sh
-brew install python libevent
-curl https://bootstrap.pypa.io/ez_setup.py -o - | python
+brew install python3 libevent
+curl https://bootstrap.pypa.io/ez_setup.py -o - | python3
 pip install gevent gunicorn
 ```
 
-* **Step 1** - Install python requirements.
+* **Step 1** - Install Python 3 requirements.
 
 ```sh
-sudo pip install -r requirements.txt
+sudo pip3 install -r requirements.txt
 ```
 
 
@@ -74,9 +74,9 @@ export DATABASE_URL=postgresql://open_event_user:start@127.0.0.1:5432/test
 * **Step 5** - Create the tables. For that we will use `create_db.py`.
 
 ```sh
-python create_db.py
+python3 create_db.py
 # enter email and password
-python manage.py db stamp head
+python3 manage.py db stamp head
 ```
 
 
@@ -102,7 +102,7 @@ celery worker -A app.celery &
 unset INTEGRATE_SOCKETIO
 
 # run app
-python manage.py runserver
+python3 manage.py runserver
 ```
 
 * **Step 8** - Rejoice. Go to `localhost:5000` in your web browser to see the application live.

--- a/docs/installation/vagrant.md
+++ b/docs/installation/vagrant.md
@@ -129,7 +129,7 @@ This will bring you to the root directory of the Virtual Machine.
 
 
 * To run the app, type
-```python create_db.py```
+```python3 create_db.py```
 this step should exit normally without raising any errors. If Terminal does report an error type
 ```echo $DATABASE_URL```
 to double check your database configuration.
@@ -138,7 +138,7 @@ to double check your database configuration.
 
 
 * Next, type
-```python manage.py runserver -h 0.0.0.0 -p 5000```
+```python3 manage.py runserver -h 0.0.0.0 -p 5000```
 
 ![screen shot 2015-12-13 at 7 22 55 pm](https://cloud.githubusercontent.com/assets/9834624/11853343/5e9cab7c-a40b-11e5-96ad-30df2a3e33a0.png)
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4739 Google Installation guide still uses python2

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:

Updating python cmd with python3 in docs.

#### Changes proposed in this pull request:

-
-
-

@Kreijstal @CosmicCoder96 Please review thanks.
