### PR TITLE
fix: Raise validation error if max_order set more than quantity of ticket

### DIFF
--- a/app/api/schema/tickets.py
+++ b/app/api/schema/tickets.py
@@ -108,6 +108,11 @@ class TicketSchema(TicketSchemaPublic):
                 raise UnprocessableEntity({'pointer': '/data/attributes/quantity'},
                                           "quantity should be greater than min-order")
 
+        if 'quantity' in data and 'max_order' in data:
+            if data['quantity'] < data['max_order']:
+                raise UnprocessableEntity({'pointer': '/data/attributes/quantity'},
+                                          "quantity should be lesser than max-order")
+
     access_codes = Relationship(attribute='access_codes',
                                 self_view='v1.ticket_access_code',
                                 self_view_kwargs={'id': '<id>'},


### PR DESCRIPTION
Fixes #4762 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Adds a schema validation check to ensure that max_order is always less than the quantity of ticket.

#### Changes proposed in this pull request:

- Added a schema validation to raise validation error if max_order is more than the quantity of ticket



