### PR TITLE
fix: TypeError in file.write [python3.5].

### DIFF
--- a/app/api/helpers/export_helpers.py
+++ b/app/api/helpers/export_helpers.py
@@ -206,7 +206,7 @@ def export_event_json(event_id, settings):
                 _download_media(data[count], e[0], dir_path, settings)
         data_str = json.dumps(data, indent=4, ensure_ascii=False).encode('utf-8')
         fp = open(dir_path + '/' + e[0], 'w')
-        fp.write(data_str)
+        fp.write(str(data_str, 'utf-8'))
         fp.close()
     # add meta
     data_str = json.dumps(
@@ -214,7 +214,7 @@ def export_event_json(event_id, settings):
         indent=4, ensure_ascii=False
     ).encode('utf-8')
     fp = open(dir_path + '/meta', 'w')
-    fp.write(data_str)
+    fp.write(str(data_str, 'utf-8'))
     fp.close()
     # make zip
     shutil.make_archive(dir_path, 'zip', dir_path)

--- a/app/api/helpers/storage.py
+++ b/app/api/helpers/storage.py
@@ -109,7 +109,7 @@ class UploadedMemory(object):
 
     def save(self, path):
         f = open(path, 'w')
-        f.write(self.data)
+        f.write(str(self.data, 'utf-8'))
         f.close()
 
 

--- a/app/api/helpers/utilities.py
+++ b/app/api/helpers/utilities.py
@@ -97,7 +97,7 @@ def get_filename_from_cd(cd):
 def write_file(file, data):
     """simple write to file"""
     fp = open(file, 'w')
-    fp.write(data)
+    fp.write(str(data, 'utf-8'))
     fp.close()
 
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4783 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Fixed the issue arising in Python 3.5 while writing to a file.

#### Changes proposed in this pull request:
- Use the solution proposed here https://stackoverflow.com/questions/13906623/using-pickle-dump-typeerror-must-be-str-not-bytes

