### PR TITLE
fix: Remove redundant info about stripe auth collection from docs

### DIFF
--- a/docs/api/api_blueprint.apib
+++ b/docs/api/api_blueprint.apib
@@ -19932,7 +19932,7 @@ This endpoint supports uploading of any kind of file or multiple files. If a sin
         }
 
 
-# Group StripeAuthorization
+# Group Stripe Authorization
 
 **Event ADMIN**
 
@@ -19946,15 +19946,11 @@ To update or get any attribute of this data layer, you will need event admin acc
 | `stripe_user_id`  | string | **yes** |
 | `stripe_email`  | string | **yes** |
 
-## StripeAuthorization Collection[/v1/stripe-authorization{?page%5bsize%5d,page%5bnumber%5d,sort,filter}]
-+ Parameters
-    + page%5bsize%5d (optional, integer, `10`) - Maximum number of resources in a single paginated response.
-    + page%5bnumber%5d (optional, integer, `2`) - Page number to fetched for the paginated response.
-    + sort (optional, string, `app-name`) - Sort the resources according to the given attribute in ascending order. Append '-' to sort in descending order.
-    + filter (optional, string, `[]`) - Filter according to the flask-rest-jsonapi filtering system. Please refer: http://flask-rest-jsonapi.readthedocs.io/en/latest/filtering.html for more.
+
+## Stripe Authorization Collection [/v1/stripe-authorization]
+Requires Co-Organizer Access
 
 ### Create Stripe Authorization [POST]
-Requires Co-Organizer Access
 
 + Request (application/vnd.api+json)
 

--- a/tests/hook_main.py
+++ b/tests/hook_main.py
@@ -3333,7 +3333,7 @@ def user_permission_delete(transaction):
 
 
 # ------------------------- Stripe Authorizations -------------------------
-@hooks.before("StripeAuthorization > StripeAuthorization Collection > Create Stripe Authorization")
+@hooks.before("Stripe Authorization > Stripe Authorization Collection > Create Stripe Authorization")
 def stripe_authorization_post(transaction):
     """
     POST /stripe-authorization
@@ -3346,7 +3346,7 @@ def stripe_authorization_post(transaction):
         db.session.commit()
 
 
-@hooks.before("StripeAuthorization > Stripe Authorization Details > Get Stripe Authorization")
+@hooks.before("Stripe Authorization > Stripe Authorization Details > Get Stripe Authorization")
 def stripe_authorization_get_detail(transaction):
     """
     GET /stripe-authorization/1
@@ -3359,7 +3359,7 @@ def stripe_authorization_get_detail(transaction):
         db.session.commit()
 
 
-@hooks.before("StripeAuthorization > Stripe Authorization Details > Update Stripe Authorization")
+@hooks.before("Stripe Authorization > Stripe Authorization Details > Update Stripe Authorization")
 def stripe_authorization_patch(transaction):
     """
     PATCH /stripe-authorization/1
@@ -3372,7 +3372,7 @@ def stripe_authorization_patch(transaction):
         db.session.commit()
 
 
-@hooks.before("StripeAuthorization > Stripe Authorization Details > Delete Stripe Authorization")
+@hooks.before("Stripe Authorization > Stripe Authorization Details > Delete Stripe Authorization")
 def stripe_authorization_delete(transaction):
     """
     DELETE /stripe-authorization/1
@@ -3385,7 +3385,7 @@ def stripe_authorization_delete(transaction):
         db.session.commit()
 
 
-@hooks.before("StripeAuthorization > Stripe Authorization for an Event > Get Stripe Authorization Details of an Event")
+@hooks.before("Stripe Authorization > Stripe Authorization for an Event > Get Stripe Authorization Details of an Event")
 def event_stripe_authorization_get_detail(transaction):
     """
     GET /events/1/stripe-authorization


### PR DESCRIPTION
Fixes #4784 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Removes redundant information about the parameters in the stripe auth collection since there is no Stripe auth collection. 

#### Changes proposed in this pull request:
- Same as above.