### PR TITLE
Fixes #4797 Custom-Form endpoint does not allow number as the type of input field

### DIFF
--- a/app/api/schema/custom_forms.py
+++ b/app/api/schema/custom_forms.py
@@ -24,7 +24,8 @@ class CustomFormSchema(Schema):
     field_identifier = fields.Str(required=True)
     form = fields.Str(required=True)
     type = fields.Str(default="text", validate=validate.OneOf(
-        choices=["text", "checkbox", "select", "file", "image", "email"]))
+        choices=["text", "checkbox", "select", "file", "image", "email",
+                 "number"]))
     is_required = fields.Boolean(default=False)
     is_included = fields.Boolean(default=False)
     is_fixed = fields.Boolean(default=False)


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4797 Custom-Form endpoint does not allow number as the type of input field

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:

Fixes #4797 Custom-Form endpoint does not allow number as the type of input field

#### Changes proposed in this pull request:

- Addition of "number" in choices of type of Custom form.
-
-

@pradeepgangwar @iamareebjamal @poush @srv-twry Please review. thanks!
