### PR TITLE
fix: Check is_ticketing_enabled flag before creating Ticket

### DIFF
--- a/app/api/tickets.py
+++ b/app/api/tickets.py
@@ -11,8 +11,9 @@ from app.models import db
 from app.models.access_code import AccessCode
 from app.models.order import Order
 from app.models.ticket import Ticket, TicketTag, ticket_tags_table
+from app.models.event import Event
 from app.models.ticket_holder import TicketHolder
-from app.api.helpers.exceptions import ConflictException
+from app.api.helpers.exceptions import ConflictException, MethodNotAllowed
 from app.api.helpers.db import get_count
 
 
@@ -35,6 +36,9 @@ class TicketListPost(ResourceList):
 
         if get_count(db.session.query(Ticket.id).filter_by(name=data['name'], event_id=int(data['event']))) > 0:
             raise ConflictException({'pointer': '/data/attributes/name'}, "Ticket already exists")
+
+        if get_count(db.session.query(Event).filter_by(id=int(data['event']), is_ticketing_enabled=False)) > 0:
+            raise MethodNotAllowed({'parameter': 'event_id'}, "Ticketing is disabled for this Event")
 
     schema = TicketSchema
     methods = ['POST', ]


### PR DESCRIPTION
Fixes #4698

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Ticket was getting creating even if `is_ticketing_enabled flag` in Event was set to false.

#### Changes proposed in this pull request:

- Method Not Allowed Exception is thrown if `is_ticketing_enabled` flag of event is false and user requests ticket creation.



