### PR TITLE
fix: Avoid comparing None in Access-Code and Discount-Code schema validation

### DIFF
--- a/app/api/schema/access_codes.py
+++ b/app/api/schema/access_codes.py
@@ -52,10 +52,14 @@ class AccessCodeSchema(Schema):
             if 'tickets_number' not in data:
                 data['tickets_number'] = access_code.tickets_number
 
-        if 'min_quantity' in data and 'max_quantity' in data:
-            if data['min_quantity'] >= data['max_quantity']:
-                raise UnprocessableEntity({'pointer': '/data/attributes/min-quantity'},
-                                          "min-quantity should be less than max-quantity")
+        min_quantity = data.get('min_quantity', None)
+        max_quantity = data.get('max_quantity', None)
+        if min_quantity is not None and max_quantity is not None:
+            if min_quantity >= max_quantity:
+                raise UnprocessableEntity(
+                    {'pointer': '/data/attributes/min-quantity'},
+                    "min-quantity should be less than max-quantity"
+                )
 
         if 'tickets_number' in data and 'max_quantity' in data:
             if data['tickets_number'] < data['max_quantity']:

--- a/app/api/schema/discount_codes.py
+++ b/app/api/schema/discount_codes.py
@@ -41,6 +41,17 @@ class DiscountCodeSchemaPublic(Schema):
                          schema='EventSchemaPublic',
                          type_='event')
 
+    @classmethod
+    def quantity_validation_helper(obj, data):
+        min_quantity = data.get('min_quantity', None)
+        max_quantity = data.get('max_quantity', None)
+        if min_quantity is not None and max_quantity is not None:
+            if min_quantity >= max_quantity:
+                raise UnprocessableEntity(
+                    {'pointer': '/data/attributes/min-quantity'},
+                    "min-quantity should be less than max-quantity"
+                )
+
 
 class DiscountCodeSchemaEvent(DiscountCodeSchemaPublic):
     """
@@ -66,10 +77,7 @@ class DiscountCodeSchemaEvent(DiscountCodeSchemaPublic):
             if 'tickets_number' not in data:
                 data['tickets_number'] = discount_code.tickets_number
 
-        if 'min_quantity' in data and 'max_quantity' in data:
-            if data['min_quantity'] >= data['max_quantity']:
-                raise UnprocessableEntity({'pointer': '/data/attributes/min-quantity'},
-                                          "min-quantity should be less than max-quantity")
+        DiscountCodeSchemaEvent.quantity_validation_helper(data)
 
         if 'tickets_number' in data and 'max_quantity' in data:
             if data['tickets_number'] < data['max_quantity']:
@@ -125,10 +133,7 @@ class DiscountCodeSchemaTicket(DiscountCodeSchemaPublic):
             if 'tickets_number' not in data:
                 data['tickets_number'] = discount_code.tickets_number
 
-        if 'min_quantity' in data and 'max_quantity' in data:
-            if data['min_quantity'] >= data['max_quantity']:
-                raise UnprocessableEntity({'pointer': '/data/attributes/min-quantity'},
-                                          "min-quantity should be less than max-quantity")
+        DiscountCodeSchemaTicket.quantity_validation_helper(data)
 
         if 'tickets_number' in data and 'max_quantity' in data:
             if data['tickets_number'] < data['max_quantity']:


### PR DESCRIPTION
Fixes #4809

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
If minimum and maximum quantities are not specified, they should not be compared, since that throws a `TypeError`. This PR adds this corresponding check.

