### PR TITLE
fix: ForbiddenException if attempting to create speaker & sessions when disabled in event

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -2,7 +2,8 @@ from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationshi
 
 from app.api.bootstrap import api
 from app.api.events import Event
-from app.api.helpers.db import safe_query
+from app.api.helpers.db import safe_query, get_count
+from app.api.helpers.exceptions import ForbiddenException
 from app.api.helpers.mail import send_email_new_session, send_email_session_accept_reject
 from app.api.helpers.notification import send_notif_new_session_organizer, send_notif_session_accept_reject
 from app.api.helpers.permissions import current_identity
@@ -33,6 +34,8 @@ class SessionListPost(ResourceList):
         """
         require_relationship(['event'], data)
         data['creator_id'] = current_identity.id
+        if get_count(db.session.query(Event).filter_by(id=int(data['event']), is_sessions_speakers_enabled=False)) > 0:
+            raise ForbiddenException({'pointer': ''}, "Sessions are disabled for this Event")
 
     def after_create_object(self, session, data, view_kwargs):
         """

--- a/app/api/speakers.py
+++ b/app/api/speakers.py
@@ -3,7 +3,8 @@ from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationshi
 from flask_rest_jsonapi.exceptions import ObjectNotFound
 
 from app.api.bootstrap import api
-from app.api.helpers.db import safe_query
+from app.api.helpers.db import safe_query, get_count
+from app.api.helpers.exceptions import ForbiddenException
 from app.api.helpers.permission_manager import has_access
 from app.api.helpers.query import event_query
 from app.api.helpers.utilities import require_relationship
@@ -35,6 +36,9 @@ class SpeakerListPost(ResourceList):
                 if event.state == "draft":
                     raise ObjectNotFound({'parameter': 'event_id'},
                                          "Event: {} not found".format(data['event_id']))
+
+        if get_count(db.session.query(Event).filter_by(id=int(data['event']), is_sessions_speakers_enabled=False)) > 0:
+            raise ForbiddenException({'pointer': ''}, "Speakers are disabled for this Event")
 
         if 'sessions' in data:
             session_ids = data['sessions']


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4817 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
It doesn't make any sense to allow to create sessions and speakers when it is disabled in the event.

#### Changes proposed in this pull request:
Forbidden exception is raised when it is attempted.


