### PR TITLE
fix: forbid sponsor creation if sponsors are disabled

### DIFF
--- a/app/api/sponsors.py
+++ b/app/api/sponsors.py
@@ -1,6 +1,8 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
 
 from app.api.bootstrap import api
+from app.api.events import Event
+from app.api.helpers.db import get_count
 from app.api.helpers.exceptions import ForbiddenException
 from app.api.helpers.permission_manager import has_access
 from app.api.helpers.query import event_query
@@ -25,6 +27,8 @@ class SponsorListPost(ResourceList):
         require_relationship(['event'], data)
         if not has_access('is_coorganizer', event_id=data['event']):
             raise ForbiddenException({'source': ''}, 'Co-organizer access is required.')
+        if get_count(db.session.query(Event).filter_by(id=int(data['event']), is_sponsors_enabled=False)) > 0:
+            raise ForbiddenException({'pointer': ''}, "Sponsors are disabled for this Event")
 
     methods = ['POST']
     schema = SponsorSchema

--- a/app/factories/event.py
+++ b/app/factories/event.py
@@ -42,7 +42,7 @@ class EventFactoryBasic(factory.alchemy.SQLAlchemyModelFactory):
     cheque_details = common.string_
     bank_details = common.string_
     onsite_details = common.string_
-    is_sponsors_enabled = False
+    is_sponsors_enabled = True
     pentabarf_url = common.url_
     ical_url = common.url_
     xcal_url = common.url_


### PR DESCRIPTION
Fixes #4819 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
It disallows creation of sponsors for an event if sponsors are disabled for that event.

#### Changes proposed in this pull request:

Forbidden Exception is raised when sponsor creation is attempted for an event with sponsors disabled.