### PR TITLE
fix: Return None if the image_file is None in create_save_resized_image

### DIFF
--- a/app/api/helpers/files.py
+++ b/app/api/helpers/files.py
@@ -74,6 +74,9 @@ def create_save_resized_image(image_file, basewidth=None, maintain_aspect=None, 
     :param image_file:
     :return:
     """
+    if not image_file:
+        return None
+
     filename = '{filename}.{ext}'.format(filename=get_file_name(), ext=ext)
     data = urllib.request.urlopen(image_file).read()
     image_file = io.BytesIO(data)


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4826 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
When trying to use Event copy to copy the event, the server errors out and sends HTTP 500. It was for a specific case when the sponsor logo url was not defined.

#### Changes proposed in this pull request:

- Return None if the image_file is None in create_save_resized_image

@bhaveshAn @schedutron @mayank8318 please review :)
