### PR TITLE
feat: Specify sending email on accept/reject for session

### DIFF
--- a/app/api/schema/sessions.py
+++ b/app/api/schema/sessions.py
@@ -75,6 +75,7 @@ class SessionSchema(Schema):
     submitted_at = fields.DateTime(allow_none=True)
     is_mail_sent = fields.Boolean()
     last_modified_at = fields.DateTime(dump_only=True)
+    send_email = fields.Boolean(load_only=True, allow_none=True)
     microlocation = Relationship(attribute='microlocation',
                                  self_view='v1.session_microlocation',
                                  self_view_kwargs={'id': '<id>'},

--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -122,7 +122,9 @@ class SessionDetail(ResourceDetail):
 
     def after_update_object(self, session, data, view_kwargs):
         """ Send email if session accepted or rejected """
-        if 'state' in data and (session.state == 'accepted' or session.state == 'rejected'):
+
+        if 'state' in data and data.get('send_email', None) and (session.state == 'accepted' or
+                                                                 session.state == 'rejected'):
             # Email for speaker
             speakers = session.speakers
             for speaker in speakers:

--- a/docs/api/api_blueprint.apib
+++ b/docs/api/api_blueprint.apib
@@ -10303,6 +10303,7 @@ Data related to all the sessions in the event.
 | `submitted-at` | Date the session was submitted | ISO 8601 (tz-aware) | - |
 | `is-mail-sent` | Yes/No for Session accept/reject email | boolean (default: `false`) | - |
 | `last-modified-at` | Date the session was modified | ISO 8601 (tz-aware) | - |
+| `send-email` | Yes/No for sending Session accept/reject email | boolean | - |
 
 
 ## Sessions Collection [/v1/sessions{?page%5bsize%5d,page%5bnumber%5d,sort,filter}]


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4830 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Currently, if we update the state of a session to Accepted or Rejected, emails are always sent to the speakers and the event organizer.

#### Changes proposed in this pull request:

- Now the schema has a load_only field which specifies whether to send the email or not. If the field is not in the data or is set to false, no email is sent to the speaker or the event organizer. 
If it is true, then emails are sent.

I wanted to fix https://github.com/fossasia/open-event-server/issues/4837 in this PR itself, but I wasn't able to figure out the problem and this PR is needed for another issue in the frontend. Hence created the new issue https://github.com/fossasia/open-event-server/issues/4837
