### PR TITLE
fix: use safe query to avoid HTTP 500 in stripe authorization

### DIFF
--- a/app/api/stripe_authorization.py
+++ b/app/api/stripe_authorization.py
@@ -84,8 +84,8 @@ class StripeAuthorizationDetail(ResourceDetail):
             view_kwargs['event_id'] = event.id
 
         if view_kwargs.get('event_id'):
-            stripe_authorization = self.session.query(StripeAuthorization).\
-                filter_by(event_id=view_kwargs['event_id']).one()
+            stripe_authorization = \
+                safe_query(self, StripeAuthorization, 'event_id', view_kwargs['event_id'], 'event_id')
             view_kwargs['id'] = stripe_authorization.id
 
     decorators = (api.has_permission('is_coorganizer', fetch="event_id",


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4866 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
The server returns HTTP 500 when we use the /event/<event_id>/stripe-authorization endpoint to fetch Stripe authorization details and no stripe config exists for the event.

#### Changes proposed in this pull request:
Use safe_query to avoid HTTP 500


