### PR TITLE
Append "s" at the end of stripe api endpoint url

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -171,7 +171,7 @@ api.route(EventDetail, 'event_detail', '/events/<int:id>', '/events/<identifier>
           '/access-codes/<int:access_code_id>/event', '/email-notifications/<int:email_notification_id>/event',
           '/attendees/<int:attendee_id>/event', '/custom-forms/<int:custom_form_id>/event',
           '/orders/<order_identifier>/event', '/faqs/<int:faq_id>/event', '/faq-types/<int:faq_type_id>/event',
-          '/feedbacks/<int:feedback_id>/event', '/stripe-authorization/<int:stripe_authorization_id>/event')
+          '/feedbacks/<int:feedback_id>/event', '/stripe-authorizations/<int:stripe_authorization_id>/event')
 api.route(EventRelationship, 'event_ticket', '/events/<int:id>/relationships/tickets',
           '/events/<identifier>/relationships/tickets')
 api.route(EventRelationship, 'event_ticket_tag', '/events/<int:id>/relationships/ticket-tags',
@@ -463,11 +463,11 @@ api.route(FeedbackRelationshipRequired, 'feedback_user',
           '/feedbacks/<int:id>/relationships/user')
 
 # Stripe Authorization API
-api.route(StripeAuthorizationListPost, 'stripe_authorization_list_post', '/stripe-authorization')
-api.route(StripeAuthorizationDetail, 'stripe_authorization_detail',  '/stripe-authorization/<int:id>',
+api.route(StripeAuthorizationListPost, 'stripe_authorization_list_post', '/stripe-authorizations')
+api.route(StripeAuthorizationDetail, 'stripe_authorization_detail',  '/stripe-authorizations/<int:id>',
           '/events/<int:event_id>/stripe-authorization', '/events/<event_identifier>/stripe-authorization')
 api.route(StripeAuthorizationRelationship, 'stripe_authorization_event',
-          '/stripe-authorization/<int:id>/relationships/event')
+          '/stripe-authorizations/<int:id>/relationships/event')
 
 # Orders API
 api.route(OrdersListPost, 'order_list_post', '/orders')

--- a/docs/api/api_blueprint.apib
+++ b/docs/api/api_blueprint.apib
@@ -3088,7 +3088,7 @@ Create a new event using a `name`, `starts-at`, `ends-at`, `timezone` and an opt
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -3333,7 +3333,7 @@ Get a single event.
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -3623,7 +3623,7 @@ All other fields are optional. Add attributes you want to modify.
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -3881,7 +3881,7 @@ Get a list of events.
                         },
                         "stripe-authorization": {
                             "links": {
-                                "self": "/v1/stripe-authorization/1/relationships/event",
+                                "self": "/v1/events/1/relationships/stripe-authorization",
                                 "related": "/v1/events/1/stripe-authorization"
                             }
                         }
@@ -4567,7 +4567,7 @@ Get a list of events.
                         },
                         "stripe-authorization": {
                             "links": {
-                                "self": "/v1/stripe-authorization/1/relationships/event",
+                                "self": "/v1/events/1/relationships/stripe-authorization",
                                 "related": "/v1/events/1/stripe-authorization"
                             }
                         }
@@ -5014,7 +5014,7 @@ Get a list of events.
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -5236,7 +5236,7 @@ Get a list of events.
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -5458,7 +5458,7 @@ Get a list of events.
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -5680,7 +5680,7 @@ Get a list of events.
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -5902,7 +5902,7 @@ Get a list of events.
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -6124,7 +6124,7 @@ Get a list of events.
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -6346,7 +6346,7 @@ Get a list of events.
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -6568,7 +6568,7 @@ Get a list of events.
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -6790,7 +6790,7 @@ Get a list of events.
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -7012,7 +7012,7 @@ Get a list of events.
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -7234,7 +7234,7 @@ Get a list of events.
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -7456,7 +7456,7 @@ Get a list of events.
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -7678,7 +7678,7 @@ Get a list of events.
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -7900,7 +7900,7 @@ Get a list of events.
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -8122,7 +8122,7 @@ Get a list of events.
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -8344,7 +8344,7 @@ Get a list of events.
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -8566,7 +8566,7 @@ Get a list of events.
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -8788,7 +8788,7 @@ Get a list of events.
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -9010,7 +9010,7 @@ Get a list of events.
                     },
                     "stripe-authorization": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/events/1/relationships/stripe-authorization",
                             "related": "/v1/events/1/stripe-authorization"
                         }
                     }
@@ -9259,7 +9259,7 @@ Get a list of events.
               },
               "stripe-authorization": {
                 "links": {
-                  "self": "/v1/stripe-authorization/1/relationships/event",
+                  "self": "/v1/events/1/relationships/stripe-authorization",
                   "related": "/v1/events/1/stripe-authorization"
                 }
               }
@@ -9325,7 +9325,7 @@ Get a list of events.
           }
         }
 
-## Get Event for a Stripe Authorization [/v1/stripe-authorization/{stripe_authorization_id}/event]
+## Get Event for a Stripe Authorization [/v1/stripe-authorizations/{stripe_authorization_id}/event]
 + Parameters
     + stripe_authorization_id : 1 (integer) - ID of the stripe authorization in the form of an integer
 
@@ -9508,7 +9508,7 @@ Get a list of events.
               },
               "stripe-authorization": {
                 "links": {
-                  "self": "/v1/stripe-authorization/1/relationships/event",
+                  "self": "/v1/events/1/relationships/stripe-authorization",
                   "related": "/v1/events/1/stripe-authorization"
                 }
               }
@@ -20362,7 +20362,7 @@ To update or get any attribute of this data layer, you will need event admin acc
 
 
 
-## Stripe Authorization Collection [/v1/stripe-authorization]
+## Stripe Authorization Collection [/v1/stripe-authorizations]
 Requires Co-Organizer Access
 
 ### Create Stripe Authorization [POST]
@@ -20399,7 +20399,7 @@ Requires Co-Organizer Access
             "relationships": {
               "event": {
                 "links": {
-                  "self": "/v1/stripe-authorization/1/relationships/event",
+                  "self": "/v1/stripe-authorizations/1/relationships/event",
                   "related": "/v1/events/1"
                 }
               }
@@ -20410,19 +20410,19 @@ Requires Co-Organizer Access
             "type": "stripe-authorization",
             "id": "1",
             "links": {
-              "self": "/v1/stripe-authorization/1"
+              "self": "/v1/stripe-authorizations/1"
             }
           },
           "jsonapi": {
             "version": "1.0"
           },
           "links": {
-            "self": "/v1/stripe-authorization/1"
+            "self": "/v1/stripe-authorizations/1"
           }
         }
 
 
-## Stripe Authorization Details [/v1/stripe-authorization/{id}]
+## Stripe Authorization Details [/v1/stripe-authorizations/{id}]
 Requires Event Co-Organizer Access
 + Parameters
     + id: 1 (integer) - ID of the stripe-authorization
@@ -20444,7 +20444,7 @@ Requires Event Co-Organizer Access
             "relationships": {
               "event": {
                 "links": {
-                  "self": "/v1/stripe-authorization/1/relationships/event",
+                  "self": "/v1/stripe-authorizations/1/relationships/event",
                   "related": "/v1/events/1"
                 }
               }
@@ -20455,14 +20455,14 @@ Requires Event Co-Organizer Access
             "type": "stripe-authorization",
             "id": "1",
             "links": {
-              "self": "/v1/stripe-authorization/1"
+              "self": "/v1/stripe-authorizations/1"
             }
           },
           "jsonapi": {
             "version": "1.0"
           },
           "links": {
-            "self": "/v1/stripe-authorization/1"
+            "self": "/v1/stripe-authorizations/1"
           }
         }
 
@@ -20494,7 +20494,7 @@ Requires Event Co-Organizer Access
             "relationships": {
               "event": {
                 "links": {
-                  "self": "/v1/stripe-authorization/1/relationships/event",
+                  "self": "/v1/stripe-authorizations/1/relationships/event",
                   "related": "/v1/events/1"
                 }
               }
@@ -20505,14 +20505,14 @@ Requires Event Co-Organizer Access
             "type": "stripe-authorization",
             "id": "1",
             "links": {
-              "self": "/v1/stripe-authorization/1"
+              "self": "/v1/stripe-authorizations/1"
             }
           },
           "jsonapi": {
             "version": "1.0"
           },
           "links": {
-            "self": "/v1/stripe-authorization/1"
+            "self": "/v1/stripe-authorizations/1"
           }
         }
 
@@ -20560,7 +20560,7 @@ Requires event admin access
                 "relationships": {
                     "event": {
                         "links": {
-                            "self": "/v1/stripe-authorization/1/relationships/event",
+                            "self": "/v1/stripe-authorizations/1/relationships/event",
                             "related": "/v1/events/1"
                         }
                     }
@@ -20571,14 +20571,14 @@ Requires event admin access
                 "type": "stripe-authorization",
                 "id": "1",
                 "links": {
-                    "self": "/v1/stripe-authorization/1"
+                    "self": "/v1/stripe-authorizations/1"
                 }
             },
             "jsonapi": {
                 "version": "1.0"
             },
             "links": {
-                "self": "/v1/stripe-authorization/1"
+                "self": "/v1/stripe-authorizations/1"
             }
         }
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4868 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Currently ember by default makes calls to stripe-authorizations whereas server has end point as stripe-authorization. All the other endpoints use "s" in the end i.e. the plural sense. There should be consistency. Ember follows conventions hence this should be added to make frontend easier to implement. This PR appends s at the end of url of stripe api. 

#### Changes proposed in this pull request:
- Append "s" to the url of stripe API.
