### PR TITLE
fix: Type Error in export as ical and xcal

### DIFF
--- a/app/api/exports.py
+++ b/app/api/exports.py
@@ -71,7 +71,7 @@ def export_event_xcal(event_identifier):
 
     if not event_identifier.isdigit():
         event = db.session.query(Event).filter_by(identifier=event_identifier).first()
-        event_id = event.id
+        event_id = str(event.id)
     else:
         event_id = event_identifier
 
@@ -99,7 +99,7 @@ def event_export_task_base(event_id, settings):
 def export_event_ical(event_identifier):
     if not event_identifier.isdigit():
         event = db.session.query(Event).filter_by(identifier=event_identifier).first()
-        event_id = event.id
+        event_id = str(event.id)
     else:
         event_id = event_identifier
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4877 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Solves type error problem faced when using the event_identifier to export

#### Changes proposed in this pull request:
- store event_id as str instead of int while doing file operations


