### PR TITLE
fix: Use BytesIO instead of StringIO to fix HTTP 500 in creating orders

### DIFF
--- a/app/api/helpers/files.py
+++ b/app/api/helpers/files.py
@@ -14,9 +14,9 @@ from sqlalchemy.orm.exc import NoResultFound
 from xhtml2pdf import pisa
 
 from app import get_settings
+from app.api.helpers.exceptions import UnprocessableEntity
 from app.api.helpers.storage import UploadedFile, upload, generate_hash, UPLOAD_PATHS
 from app.models.image_size import ImageSizes
-from app.api.helpers.exceptions import UnprocessableEntity
 
 
 def get_file_name():
@@ -211,7 +211,7 @@ def create_save_pdf(pdf_data):
     dest = filedir + filename
 
     file = open(dest, "wb")
-    pisa.CreatePDF(io.StringIO(pdf_data.encode('utf-8')), file)
+    pisa.CreatePDF(io.BytesIO(pdf_data.encode('utf-8')), file)
     file.close()
 
     uploaded_file = UploadedFile(dest, filename)

--- a/app/models/ticket_holder.py
+++ b/app/models/ticket_holder.py
@@ -1,5 +1,5 @@
 import base64
-from io import StringIO
+from io import BytesIO
 
 import qrcode
 
@@ -134,7 +134,7 @@ class TicketHolder(db.Model):
         qr.make(fit=True)
         img = qr.make_image()
 
-        buffer = StringIO()
+        buffer = BytesIO()
         img.save(buffer, format="JPEG")
         img_str = str(base64.b64encode(buffer.getvalue()), 'utf-8')
         return img_str


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4890 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Resolves HTTP 500 in creating an order. Stacktrace in the issue

#### Changes proposed in this pull request:
Use BytesIO instead of StringIO to fix the issue. 
Reference here: https://stackoverflow.com/questions/6479100/python-stringio-replacement-that-works-with-bytes-instead-of-strings


#### Screenshot
![working_create_order](https://user-images.githubusercontent.com/21277837/41420087-4cfda7de-7011-11e8-8330-c568f5c56067.png)

