### PR TITLE
fix: Use separate app context for celery workers

### DIFF
--- a/app/api/helpers/tasks.py
+++ b/app/api/helpers/tasks.py
@@ -1,10 +1,11 @@
+import os
+
 import requests
+from flask import current_app
 from marrow.mailer import Mailer, Message
 
+from app import make_celery
 from app.api.helpers.utilities import strip_tags
-from app.views.celery_ import celery
-from flask import current_app
-import os
 
 """
 Define all API v2 celery tasks here
@@ -28,6 +29,8 @@ from app.api.helpers.xcal import XCalExporter
 from app.api.helpers.pentabarfxml import PentabarfExporter
 from app.api.helpers.storage import UploadedFile, upload, UPLOAD_PATHS
 from app.api.helpers.db import save_to_db
+
+celery = make_celery()
 
 
 @celery.task(name='send.email.post')


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4775 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Only the first celery task works on the server. More details in the issue.

#### Changes proposed in this pull request:
- Use separated app context for celery workers in order to fix it. 

Reference: https://stackoverflow.com/a/25408052/6748052