### PR TITLE
Add condition to before_post to check if user is verified

### DIFF
--- a/app/api/events.py
+++ b/app/api/events.py
@@ -107,13 +107,16 @@ class EventList(ResourceList):
         return query_
 
     def before_post(self, args, kwargs, data=None):
-        """
+        """he 
         before post method to verify if the event location is provided before publishing the event
         :param args:
         :param kwargs:
         :param data:
         :return:
         """
+        if data.get('state', None) == 'published' and not User.query.filter_by(id=kwargs['user_id']).first().is_verified:
+            raise ForbiddenException({'source': ''},
+                                    "Only verified accounts can publish events")
         if data.get('state', None) == 'published' and not data.get('location_name', None):
             raise ConflictException({'pointer': '/data/attributes/location-name'},
                                     "Location is required to publish the event")

--- a/populate_db.py
+++ b/populate_db.py
@@ -194,7 +194,7 @@ def create_user_permissions():
     # Create Event
     user_perm, _ = get_or_create(UserPermission, name='create_event',
                                  description='Create event')
-    user_perm.verified_user, user_perm.unverified_user = True, True
+    user_perm.verified_user, user_perm.unverified_user = True, False
     db.session.add(user_perm)
 
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4955

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Unverified Users shouldn't be able to publish events, this solves this issue.

#### Changes proposed in this pull request:

- Create a condition on before_post from the event api so that it checks for user verification
- It will throw a forbidden exception when the user is not verified.
