### PR TITLE
fix: Set current user on the order to fix HTTP 403 for attendees under an order

### DIFF
--- a/app/api/attendees.py
+++ b/app/api/attendees.py
@@ -77,7 +77,7 @@ class AttendeeList(ResourceList):
 
         if view_kwargs.get('order_identifier'):
             order = safe_query(self, Order, 'identifier', view_kwargs['order_identifier'], 'order_identifier')
-            if not has_access('is_registrar', event_id=order.event_id) or not has_access('is_user_itself',
+            if not has_access('is_registrar', event_id=order.event_id) and not has_access('is_user_itself',
                                                                                          user_id=order.user_id):
                 raise ForbiddenException({'source': ''}, 'Access Forbidden')
             query_ = query_.join(Order).filter(Order.id == order.id)

--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -107,6 +107,7 @@ class OrdersListPost(ResourceList):
             od = OrderTicket(order_id=order.id, ticket_id=ticket, quantity=order_tickets[ticket])
             save_to_db(od)
         order.quantity = order.get_tickets_count()
+        order.user = current_user
         save_to_db(order)
         if not has_access('is_coorganizer', event_id=data['event']):
             TicketingManager.calculate_update_amount(order)


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4899 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
HTTP 403 when trying to fetch attendees under an order.

#### Changes proposed in this pull request:
Set the user who created the order on the order after creating it.

![fixed](https://user-images.githubusercontent.com/21277837/41820087-963e5ecc-77e9-11e8-86d4-210f14e12d3a.png)