### PR TITLE
fix: Send email/notifications only if order status is completed

### DIFF
--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -113,12 +113,15 @@ class OrdersListPost(ResourceList):
         save_to_db(order)
         if not has_access('is_coorganizer', event_id=data['event']):
             TicketingManager.calculate_update_amount(order)
-        send_email_to_attendees(order, current_user.id)
-        send_notif_to_attendees(order, current_user.id)
 
-        order_url = make_frontend_url(path='/orders/{identifier}'.format(identifier=order.identifier))
-        for organizer in order.event.organizers:
-            send_notif_ticket_purchase_organizer(organizer, order.invoice_number, order_url, order.event.name)
+        # send e-mail and notifications if the order status is completed
+        if order.status == 'completed':
+            send_email_to_attendees(order, current_user.id)
+            send_notif_to_attendees(order, current_user.id)
+
+            order_url = make_frontend_url(path='/orders/{identifier}'.format(identifier=order.identifier))
+            for organizer in order.event.organizers:
+                send_notif_ticket_purchase_organizer(organizer, order.invoice_number, order_url, order.event.name)
 
         data['user_id'] = current_user.id
 

--- a/app/api/schema/orders.py
+++ b/app/api/schema/orders.py
@@ -53,7 +53,7 @@ class OrderSchema(SoftDeletionSchema):
     exp_month = fields.Str(dump_only=True)
     exp_year = fields.Str(dump_only=True)
     last4 = fields.Str(dump_only=True)
-    status = fields.Str(validate=validate.OneOf(choices=["pending", "cancelled", "confirmed", "deleted"]))
+    status = fields.Str(validate=validate.OneOf(choices=["pending", "cancelled", "completed", "placed", "expired"]))
     discount_code_id = fields.Str()
     payment_url = fields.Str(dump_only=True)
     cancel_note = fields.Str()

--- a/docs/api/api_blueprint.apib
+++ b/docs/api/api_blueprint.apib
@@ -21642,7 +21642,7 @@ Get the task status and the final result of the task as response
 | `country` | Country of the purchaser | boolean | **yes** |
 | `zipcode` | Zipcode of the address | string | - |
 | `payment-mode` | Mode of payment (free,stripe,paypal) | string | **yes** |
-| `status` | Status of the order | string (default=pending) | - |
+| `status` | Status of the order(pending, completed, placed, cancelled, expired) | string (default=pending) | - |
 | `discount_code_id` | ID of the discount code | string | - |
 
 ## Orders Collection [/v1/orders{?page%5bsize%5d,page%5bnumber%5d,sort,filter}]


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4970 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Right now we are sending pdf tickets and notifications in the after_create_object of the orders endpoint regardless of the state of the order.

#### Changes proposed in this pull request:
Only send notifications and tickets when the payment is successful.


