### PR TITLE
fix: Allow access codes on hidden tickets only

### DIFF
--- a/app/api/access_codes.py
+++ b/app/api/access_codes.py
@@ -1,9 +1,11 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
 from flask_rest_jsonapi.exceptions import ObjectNotFound
+from sqlalchemy.orm.exc import NoResultFound
 
 from app.api.bootstrap import api
 from app.api.helpers.db import safe_query
-from app.api.helpers.exceptions import ForbiddenException, UnprocessableEntity
+from app.api.helpers.exceptions import ForbiddenException, ConflictException
+from app.api.helpers.exceptions import UnprocessableEntity
 from app.api.helpers.permission_manager import has_access
 from app.api.helpers.permissions import jwt_required
 from app.api.helpers.query import event_query
@@ -31,11 +33,33 @@ class AccessCodeListPost(ResourceList):
         if not has_access('is_coorganizer', event_id=data['event']):
             raise ForbiddenException({'source': ''}, "Minimum Organizer access required")
 
+    def before_create_object(self, data, view_kwargs):
+        """
+        before create object method for AccessCodeListPost Class
+        :param data:
+        :param view_kwargs:
+        :return:
+        """
+        if data.get('tickets', None):
+            for ticket in data['tickets']:
+                # Ensuring that the ticket exists and is hidden.
+                try:
+                    ticket_object = self.session.query(Ticket).filter_by(id=int(ticket),
+                                                                         deleted_at=None).one()
+                    if not ticket_object.is_hidden:
+                        raise ConflictException({'pointer': '/data/relationships/tickets'},
+                                                "Ticket with id {} is public.".format(ticket) +
+                                                " Access code cannot be applied to public tickets")
+                except NoResultFound:
+                    raise ConflictException({'pointer': '/data/relationships/tickets'},
+                                            "Ticket with id {} does not exists".format(str(ticket)))
+
     schema = AccessCodeSchema
     methods = ['POST', ]
     data_layer = {'session': db.session,
-                  'model': AccessCode
-                  }
+                  'model': AccessCode,
+                  'methods': {'before_create_object': before_create_object
+                              }}
 
 
 class AccessCodeList(ResourceList):

--- a/app/api/schema/access_codes.py
+++ b/app/api/schema/access_codes.py
@@ -55,17 +55,16 @@ class AccessCodeSchema(SoftDeletionSchema):
 
         min_quantity = data.get('min_quantity', None)
         max_quantity = data.get('max_quantity', None)
-        if min_quantity is not None and max_quantity is not None:
-            if min_quantity > max_quantity:
-                raise UnprocessableEntity(
+        tickets_number = data.get('tickets_number', None)
+        if min_quantity and max_quantity and (min_quantity > max_quantity):
+            raise UnprocessableEntity(
                     {'pointer': '/data/attributes/min-quantity'},
                     "min-quantity should be less than max-quantity"
-                )
+            )
 
-        if 'tickets_number' in data and 'max_quantity' in data:
-            if data['tickets_number'] < data['max_quantity']:
-                raise UnprocessableEntity({'pointer': '/data/attributes/tickets-number'},
-                                          "tickets-number should be greater than max-quantity")
+        if tickets_number and max_quantity and (tickets_number < max_quantity):
+            raise UnprocessableEntity({'pointer': '/data/attributes/tickets-number'},
+                                      "tickets-number should be greater than max-quantity")
 
     id = fields.Integer(dump_ony=True)
     code = fields.Str(required=True)


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4971 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Right now we are allowing access code to be linked to any ticket.

#### Changes proposed in this pull request:
allow creating access codes only for hidden tickets.
Also fixed HTTP 500 in access code creating when ticket quantity is none.

##### Conflict
![conflict](https://user-images.githubusercontent.com/21277837/41994901-8fdd1c4a-7a6d-11e8-9553-cab72a4b5143.png)

##### Success
![success](https://user-images.githubusercontent.com/21277837/41994907-96012eae-7a6d-11e8-83c1-edb6bed33424.png)

