### PR TITLE
fix: Add attribute name in relationships of Order schema

### DIFF
--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -190,6 +190,7 @@ class OrderDetail(ResourceDetail):
         :param view_kwargs:
         :return:
         """
+        # Admin can update all the fields while Co-organizer can update only the status
         if not has_access('is_admin'):
             for element in data:
                 if element != 'status':

--- a/app/api/schema/orders.py
+++ b/app/api/schema/orders.py
@@ -67,7 +67,8 @@ class OrderSchema(SoftDeletionSchema):
                              many=True,
                              type_='attendee')
 
-    tickets = Relationship(self_view='v1.order_ticket',
+    tickets = Relationship(attribute='tickets',
+                           self_view='v1.order_ticket',
                            self_view_kwargs={'order_identifier': '<identifier>'},
                            related_view='v1.ticket_list',
                            related_view_kwargs={'order_identifier': '<identifier>'},
@@ -75,28 +76,32 @@ class OrderSchema(SoftDeletionSchema):
                            many=True,
                            type_="ticket")
 
-    user = Relationship(self_view='v1.order_user',
+    user = Relationship(attribute='user',
+                        self_view='v1.order_user',
                         self_view_kwargs={'order_identifier': '<identifier>'},
                         related_view='v1.user_detail',
                         related_view_kwargs={'id': '<user_id>'},
                         schema='UserSchemaPublic',
                         type_="user")
 
-    event = Relationship(self_view='v1.order_event',
+    event = Relationship(attribute='event',
+                         self_view='v1.order_event',
                          self_view_kwargs={'order_identifier': '<identifier>'},
                          related_view='v1.event_detail',
                          related_view_kwargs={'id': '<event_id>'},
                          schema='EventSchemaPublic',
                          type_="event")
 
-    marketer = Relationship(self_view='v1.order_marketer',
+    marketer = Relationship(attribute='marketer',
+                            self_view='v1.order_marketer',
                             self_view_kwargs={'order_identifier': '<identifier>'},
                             related_view='v1.user_detail',
                             related_view_kwargs={'id': '<marketer_id>'},
                             schema='UserSchemaPublic',
                             type_="user")
 
-    discount_code = Relationship(self_view='v1.order_discount',
+    discount_code = Relationship(attribute='discount_code',
+                                 self_view='v1.order_discount',
                                  self_view_kwargs={'order_identifier': '<identifier>'},
                                  related_view='v1.discount_code_detail',
                                  related_view_kwargs={'id': '<discount_code_id>'},


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4977 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Attributes aren't provided for relationships in Order schema.

#### Changes proposed in this pull request:
Added attribute name


