### PR TITLE
fix: Automatically set email_notification for the organiser on event creation

### DIFF
--- a/app/api/events.py
+++ b/app/api/events.py
@@ -138,6 +138,12 @@ class EventList(ResourceList):
         role_invite = RoleInvite(user.email, role.title_name, event.id, role.id, datetime.now(pytz.utc),
                                  status='accepted')
         save_to_db(role_invite, 'Organiser Role Invite Added')
+
+        email_notification = EmailNotification(next_event=True, new_paper=True, session_accept_reject=True,
+                                               session_schedule=True, after_ticket_purchase=True)
+        email_notification.user = user
+        email_notification.event = event
+        save_to_db(email_notification, 'Email Notification of event added to user')
         if event.state == 'published' and event.schedule_published_on:
             start_export_tasks(event)
 

--- a/app/api/schema/email_notifications.py
+++ b/app/api/schema/email_notifications.py
@@ -21,7 +21,7 @@ class EmailNotificationSchema(SoftDeletionSchema):
         self_view_kwargs = {'id': '<id>'}
         inflect = dasherize
 
-    id = fields.Str(dump_only=True)
+    id = fields.Integer(dump_only=True)
     next_event = fields.Boolean(default=False, allow_none=True)
     new_paper = fields.Boolean(default=False, allow_none=True)
     session_accept_reject = fields.Boolean(default=False, allow_none=True)

--- a/app/models/email_notification.py
+++ b/app/models/email_notification.py
@@ -5,8 +5,7 @@ from app.models.base import SoftDeletionModel
 class EmailNotification(SoftDeletionModel):
     """email notifications model class"""
     __tablename__ = 'email_notifications'
-    id = db.Column(db.Integer,
-                   primary_key=True)
+    id = db.Column(db.Integer, primary_key=True)
     next_event = db.Column(db.Boolean, default=False)
     new_paper = db.Column(db.Boolean, default=False)
     session_accept_reject = db.Column(db.Boolean, default=False)


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4927 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Automatically set the email_notification for the organiser on event creation. By default everything is set to true

#### Changes proposed in this pull request:
- Automatically set the email_notification for the organiser in the `after_create_object` method of events api


