### PR TITLE
feat: Send published events to registered users

### DIFF
--- a/app/api/events.py
+++ b/app/api/events.py
@@ -59,7 +59,8 @@ class EventList(ResourceList):
         :param kwargs:
         :return:
         """
-        if 'Authorization' in request.headers and (has_access('is_admin') or kwargs.get('user_id')):
+        if 'Authorization' in request.headers and (has_access('is_admin') or has_access('is_user_itself',
+                                                                                        user_id=kwargs.get('user_id'))):
             self.schema = EventSchema
         else:
             self.schema = EventSchemaPublic
@@ -80,7 +81,9 @@ class EventList(ResourceList):
 
         if view_kwargs.get('user_id') and 'GET' in request.method:
             if not has_access('is_user_itself', user_id=int(view_kwargs['user_id'])):
-                raise ForbiddenException({'source': ''}, 'Access Forbidden')
+                # other registered users can see the published events of the user.
+                query_ = query_.filter_by(state='published')
+
             user = safe_query(db, User, 'id', view_kwargs['user_id'], 'user_id')
             query_ = query_.join(Event.roles).filter_by(user_id=user.id).join(UsersEventsRoles.role). \
                 filter(Role.name != ATTENDEE)
@@ -116,9 +119,9 @@ class EventList(ResourceList):
         :return:
         """
         is_verified = User.query.filter_by(id=kwargs['user_id']).first().is_verified
-        if (data.get('state', None) == 'published' and not is_verified):
+        if data.get('state', None) == 'published' and not is_verified:
             raise ForbiddenException({'source': ''},
-                                      "Only verified accounts can publish events")
+                                     "Only verified accounts can publish events")
         if data.get('state', None) == 'published' and not data.get('location_name', None):
             raise ConflictException({'pointer': '/data/attributes/location-name'},
                                     "Location is required to publish the event")

--- a/app/api/schema/events.py
+++ b/app/api/schema/events.py
@@ -254,6 +254,20 @@ class EventSchemaPublic(SoftDeletionSchema):
                                 schema='CustomFormSchema',
                                 many=True,
                                 type_='custom-form')
+    organizers = Relationship(attribute='organizers',
+                              self_view='v1.event_organizers',
+                              self_view_kwargs={'id': '<id>'},
+                              related_view='v1.user_list',
+                              schema='UserSchemaPublic',
+                              type_='user',
+                              many=True)
+    coorganizers = Relationship(attribute='coorganizers',
+                                self_view='v1.event_coorganizers',
+                                self_view_kwargs={'id': '<id>'},
+                                related_view='v1.user_list',
+                                schema='UserSchemaPublic',
+                                type_='user',
+                                many=True)
 
 
 class EventSchema(EventSchemaPublic):
@@ -279,20 +293,6 @@ class EventSchema(EventSchemaPublic):
                                   related_view_kwargs={'event_id': '<id>'},
                                   schema='DiscountCodeSchema',
                                   type_='discount-code')
-    organizers = Relationship(attribute='organizers',
-                              self_view='v1.event_organizers',
-                              self_view_kwargs={'id': '<id>'},
-                              related_view='v1.user_list',
-                              schema='UserSchemaPublic',
-                              type_='user',
-                              many=True)
-    coorganizers = Relationship(attribute='coorganizers',
-                                self_view='v1.event_coorganizers',
-                                self_view_kwargs={'id': '<id>'},
-                                related_view='v1.user_list',
-                                schema='UserSchemaPublic',
-                                type_='user',
-                                many=True)
     track_organizers = Relationship(attribute='track_organizers',
                                     self_view='v1.event_track_organizers',
                                     self_view_kwargs={'id': '<id>'},


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4928 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
There is no way to list all the published events under a user. It is needed in the general app.

#### Changes proposed in this pull request:
- Adds the organizer link to the public schema.
- Lists the published events under a user when asked by a different user instead of raising AccessForbidden exception.

#### Screenshot
![a](https://user-images.githubusercontent.com/21277837/42131944-2c8a33ba-7d2b-11e8-872c-e5b25185652b.png)



