### PR TITLE
fix: Set allow_none to true in fields of order schema

### DIFF
--- a/app/api/schema/orders.py
+++ b/app/api/schema/orders.py
@@ -39,11 +39,11 @@ class OrderSchema(SoftDeletionSchema):
     id = fields.Str(dump_only=True)
     identifier = fields.Str(dump_only=True)
     amount = fields.Float(validate=lambda n: n > 0)
-    address = fields.Str()
-    city = fields.Str()
-    state = fields.Str(db.String)
-    country = fields.Str()
-    zipcode = fields.Str()
+    address = fields.Str(allow_none=True)
+    city = fields.Str(allow_none=True)
+    state = fields.Str(db.String, allow_none=True)
+    country = fields.Str(allow_none=True)
+    zipcode = fields.Str(allow_none=True)
     completed_at = fields.DateTime(dump_only=True)
     transaction_id = fields.Str(dump_only=True)
     payment_mode = fields.Str(default="free",
@@ -54,9 +54,9 @@ class OrderSchema(SoftDeletionSchema):
     exp_year = fields.Str(dump_only=True)
     last4 = fields.Str(dump_only=True)
     status = fields.Str(validate=validate.OneOf(choices=["pending", "cancelled", "completed", "placed", "expired"]))
-    discount_code_id = fields.Str()
+    discount_code_id = fields.Str(allow_none=True)
     payment_url = fields.Str(dump_only=True)
-    cancel_note = fields.Str()
+    cancel_note = fields.Str(allow_none=True)
     order_notes = fields.Str(allow_none=True)
 
     attendees = Relationship(attribute='ticket_holders',


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5021 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
HTTP 422 when creating an order with non-required fields as null.

#### Changes proposed in this pull request:
Adds allow_none to true in the non-required fields of Order schema.

