### PR TITLE
fix: Allow amount to be null for a free order

### DIFF
--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -69,6 +69,10 @@ class OrdersListPost(ResourceList):
         if data.get('cancel_note'):
             del data['cancel_note']
 
+        if data.get('payment_mode') != 'free' and not data.get('amount'):
+            raise ConflictException({'pointer': '/data/attributes/amount'},
+                                    "Amount cannot be null for a paid order")
+
         # Apply discount only if the user is not event admin
         if data.get('discount') and not has_access('is_coorganizer', event_id=data['event']):
             discount_code = safe_query_without_soft_deleted_entries(self, DiscountCode, 'id', data['discount'],

--- a/app/api/schema/orders.py
+++ b/app/api/schema/orders.py
@@ -38,7 +38,7 @@ class OrderSchema(SoftDeletionSchema):
 
     id = fields.Str(dump_only=True)
     identifier = fields.Str(dump_only=True)
-    amount = fields.Float(validate=lambda n: n > 0)
+    amount = fields.Float(validate=lambda n: n > 0, allow_none=True)
     address = fields.Str(allow_none=True)
     city = fields.Str(allow_none=True)
     state = fields.Str(db.String, allow_none=True)


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5031 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Allow amount to be null for a free order. Disallow amount to be null for a paid order.

#### Changes proposed in this pull request:
Made required changes.

#### Screenshots
![null_allowed](https://user-images.githubusercontent.com/21277837/42373028-5fc17ef0-8131-11e8-92d9-55534651a7b4.png)
![amount_paid](https://user-images.githubusercontent.com/21277837/42373026-5f8cbb70-8131-11e8-8167-cb1742e6113a.png)
