### PR TITLE
fix: HTTP 422 wrongly raised for Discount code when min-qty is equal …

### DIFF
--- a/app/api/schema/discount_codes.py
+++ b/app/api/schema/discount_codes.py
@@ -47,10 +47,10 @@ class DiscountCodeSchemaPublic(SoftDeletionSchema):
         min_quantity = data.get('min_quantity', None)
         max_quantity = data.get('max_quantity', None)
         if min_quantity is not None and max_quantity is not None:
-            if min_quantity >= max_quantity:
+            if min_quantity > max_quantity:
                 raise UnprocessableEntity(
                     {'pointer': '/data/attributes/min-quantity'},
-                    "min-quantity should be less than max-quantity"
+                    "min-quantity cannot be more than max-quantity"
                 )
 
 


### PR DESCRIPTION
…to max-qty

<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5053 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Change `>=` to `>`

#### Changes proposed in this pull request:
- Change `>=` to '>' to allow equal min and max quantity