### PR TITLE
feat: Make order accessible through id

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -509,7 +509,7 @@ api.route(StripeAuthorizationRelationship, 'stripe_authorization_event',
 api.route(OrdersListPost, 'order_list_post', '/orders')
 api.route(OrdersList, 'orders_list', '/orders', '/events/<int:event_id>/orders',
           '/events/<event_identifier>/orders', '/users/<int:user_id>/orders')
-api.route(OrderDetail, 'order_detail', '/orders/<order_identifier>',
+api.route(OrderDetail, 'order_detail', '/orders/<int:id>', '/orders/<order_identifier>',
           '/attendees/<int:attendee_id>/order')
 
 # Charges API

--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -200,8 +200,11 @@ class OrderDetail(ResourceDetail):
         if view_kwargs.get('attendee_id'):
             attendee = safe_query(self, TicketHolder, 'id', view_kwargs['attendee_id'], 'attendee_id')
             view_kwargs['order_identifier'] = attendee.order.identifier
-
-        order = safe_query(self, Order, 'identifier', view_kwargs['order_identifier'], 'order_identifier')
+        if view_kwargs.get('order_identifier'):
+            order = safe_query(self, Order, 'identifier', view_kwargs['order_identifier'], 'order_identifier')
+            view_kwargs['id'] = order.id
+        elif view_kwargs.get('id'):
+            order = safe_query(self, Order, 'id', view_kwargs['id'], 'id')
 
         if not has_access('is_coorganizer_or_user_itself', event_id=order.event_id, user_id=order.user_id):
             return ForbiddenException({'source': ''}, 'You can only access your orders or your event\'s orders')
@@ -292,8 +295,6 @@ class OrderDetail(ResourceDetail):
     schema = OrderSchema
     data_layer = {'session': db.session,
                   'model': Order,
-                  'url_field': 'order_identifier',
-                  'id_field': 'identifier',
                   'methods': {
                       'before_update_object': before_update_object,
                       'before_delete_object': before_delete_object,


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5067 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
PATCH/GET/DELETE endpoints throw 404 when accessing an order via id.

#### Changes proposed in this pull request:
Made Orders accessible through it's id.
![id](https://user-images.githubusercontent.com/21277837/42576346-c62e8b76-853f-11e8-8ad3-1b409d7b0193.png)
![identifier](https://user-images.githubusercontent.com/21277837/42576347-c66b8cec-853f-11e8-8028-cbf228d38232.png)




