### PR TITLE
Fix KeyError for order cancellation notifications

### DIFF
--- a/app/api/helpers/system_notifications.py
+++ b/app/api/helpers/system_notifications.py
@@ -114,7 +114,7 @@ NOTIFS = {
     },
     TICKET_CANCELLED: {
         'recipient': 'User',
-        'subject': u'Your order for {event_name} has been cancelled ({invoice_id})',
+        'title': u'Your order for {event_name} has been cancelled ({invoice_id})',
         'message': (
             u"Your order for {event_name} has been cancelled by the organizer"
             u"<br/>Please contact the organizer for more info" +
@@ -123,7 +123,7 @@ NOTIFS = {
     },
     TICKET_CANCELLED_ORGANIZER: {
         'recipient': 'User',
-        'subject': u'Order ({invoice_id}) has been cancelled',
+        'title': u'Order ({invoice_id}) has been cancelled',
         'message': (
             u"Order ({invoice_id}) has been cancelled"
             u"<br/>Cancel Note: {cancel_note}."


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5078

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
This PR fixed the `KeyError` in #5078 by changing `subject` to `title` for order cancellation notifications.

#### Changes proposed in this pull request:
- Change dictionary key names


