### PR TITLE
feat: Expire outdated orders automatically in the server

### DIFF
--- a/app/api/helpers/order.py
+++ b/app/api/helpers/order.py
@@ -1,4 +1,8 @@
 import logging
+from datetime import timedelta, datetime, timezone
+
+from app.api.helpers.db import save_to_db
+from app.api.helpers import ticketing
 
 
 def delete_related_attendees_for_order(self, order):
@@ -15,3 +19,19 @@ def delete_related_attendees_for_order(self, order):
         except Exception as e:
             logging.error('DB Exception! %s' % e)
             self.session.rollback()
+
+
+def set_expiry_for_order(order, override=False):
+    """
+    Expire the order after the time slot(10 minutes) if the order is pending.
+    Also expires the order if we want to expire an order regardless of the state and time.
+    :param order: Order to be expired.
+    :param override: flag to force expiry.
+    :return:
+    """
+    if order and not order.paid_via and (override or (order.status == 'pending' and (
+                order.created_at +
+                timedelta(minutes=ticketing.TicketingManager.get_order_expiry())) < datetime.now(timezone.utc))):
+            order.status = 'expired'
+            save_to_db(order)
+    return order

--- a/app/factories/order.py
+++ b/app/factories/order.py
@@ -13,3 +13,4 @@ class OrderFactory(factory.alchemy.SQLAlchemyModelFactory):
     event = factory.RelatedFactory(EventFactoryBasic)
     event_id = 1
     payment_mode = 'free'
+    status = 'pending'

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -100,7 +100,7 @@ class Order(SoftDeletionModel):
         self.event_id = event_id
         self.transaction_id = transaction_id
         self.paid_via = paid_via
-        self.created_at = datetime.datetime.utcnow()
+        self.created_at = datetime.datetime.now(datetime.timezone.utc)
         self.discount_code_id = discount_code_id
         self.status = status
         self.payment_mode = payment_mode

--- a/tests/unittests/api/helpers/test_order.py
+++ b/tests/unittests/api/helpers/test_order.py
@@ -1,0 +1,32 @@
+import unittest
+from datetime import timedelta, datetime, timezone
+
+from app import current_app as app
+from app.api.helpers import ticketing
+from app.api.helpers.order import set_expiry_for_order
+from app.factories.order import OrderFactory
+from tests.unittests.setup_database import Setup
+from tests.unittests.utils import OpenEventTestCase
+
+
+class TestOrderUtilities(OpenEventTestCase):
+    def setUp(self):
+        self.app = Setup.create_app()
+
+    def test_should_expire_outdated_order(self):
+        with app.test_request_context():
+            obj = OrderFactory()
+            obj.created_at = datetime.now(timezone.utc) - timedelta(
+                minutes=ticketing.TicketingManager.get_order_expiry() + 10)
+            set_expiry_for_order(obj)
+            self.assertEqual(obj.status, 'expired')
+
+    def test_should_not_expire_valid_orders(self):
+        with app.test_request_context():
+            obj = OrderFactory()
+            set_expiry_for_order(obj)
+            self.assertEqual(obj.status, 'pending')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5085 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
The outdated orders should be expired automatically after the set time(10 minutes as of now)

#### Changes proposed in this pull request:
- Before every GET request for either a list or a single order, we check for expiry of the order
- Added tests for the helper method.


