### PR TITLE
fix: Do not allow duplicate speaker creation

### DIFF
--- a/app/api/speakers.py
+++ b/app/api/speakers.py
@@ -40,6 +40,10 @@ class SpeakerListPost(ResourceList):
         if get_count(db.session.query(Event).filter_by(id=int(data['event']), is_sessions_speakers_enabled=False)) > 0:
             raise ForbiddenException({'pointer': ''}, "Speakers are disabled for this Event")
 
+        if get_count(db.session.query(Speaker).filter_by(event_id=int(data['event']), email=data['email'],
+                                                         deleted_at=None)) > 0:
+            raise ForbiddenException({'pointer': ''}, 'Speaker with this Email ID already exists')
+
         if 'sessions' in data:
             session_ids = data['sessions']
             for session_id in session_ids:


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5083 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Add a check to see if a speaker already exists with that email id for the given event.

#### Changes proposed in this pull request:
- `raise ForbiddenException({'pointer': ''}, 'Speaker with this Email ID already exists')` if a speaker with that email id already exists for that event.
