### PR TITLE
fix: Set allow_none for payment_mode in Order

### DIFF
--- a/app/api/schema/orders.py
+++ b/app/api/schema/orders.py
@@ -50,7 +50,7 @@ class OrderSchema(SoftDeletionSchema):
     created_at = fields.DateTime(dump_only=True)
     transaction_id = fields.Str(dump_only=True)
     payment_mode = fields.Str(default="free",
-                              validate=validate.OneOf(choices=["free", "stripe", "paypal"]))
+                              validate=validate.OneOf(choices=["free", "stripe", "paypal"]), allow_none=True)
     paid_via = fields.Str(dump_only=True)
     brand = fields.Str(dump_only=True)
     exp_month = fields.Str(dump_only=True)

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -21,7 +21,8 @@ def get_updatable_fields():
     """
     :return: The list of fields which can be modified by the order user using the pre payment form.
     """
-    return ['country', 'address', 'city', 'state', 'zipcode', 'status', 'paid_via', 'order_notes', 'deleted_at', 'user']
+    return ['country', 'address', 'city', 'state', 'zipcode', 'status', 'paid_via', 'order_notes', 'deleted_at', 'user',
+            'payment_mode']
 
 
 class OrderTicket(SoftDeletionModel):


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5106 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Since we do not know the payment_mode on order creation this field should be optional and can be updated when user updated attendees.

#### Changes proposed in this pull request:
Made it optional and updatable.


