### PR TITLE
fix: delete attendees after order expires

### DIFF
--- a/app/api/helpers/order.py
+++ b/app/api/helpers/order.py
@@ -1,24 +1,24 @@
 import logging
 from datetime import timedelta, datetime, timezone
 
-from app.api.helpers.db import save_to_db
 from app.api.helpers import ticketing
+from app.api.helpers.db import save_to_db
+from app.models import db
 
 
-def delete_related_attendees_for_order(self, order):
+def delete_related_attendees_for_order(order):
     """
     Delete the associated attendees of an order when it is cancelled/deleted/expired
-    :param self:
     :param order: Order whose attendees have to be deleted.
     :return:
     """
     for ticket_holder in order.ticket_holders:
-        self.session.delete(ticket_holder)
+        db.session.delete(ticket_holder)
         try:
-            self.session.commit()
+            db.session.commit()
         except Exception as e:
             logging.error('DB Exception! %s' % e)
-            self.session.rollback()
+            db.session.rollback()
 
 
 def set_expiry_for_order(order, override=False):
@@ -33,5 +33,6 @@ def set_expiry_for_order(order, override=False):
                 order.created_at +
                 timedelta(minutes=ticketing.TicketingManager.get_order_expiry())) < datetime.now(timezone.utc))):
             order.status = 'expired'
+            delete_related_attendees_for_order(order)
             save_to_db(order)
     return order

--- a/app/api/helpers/ticketing.py
+++ b/app/api/helpers/ticketing.py
@@ -119,7 +119,7 @@ class TicketingManager(object):
             save_to_db(order)
 
             # delete related attendees to unlock the tickets
-            delete_related_attendees_for_order(db, order)
+            delete_related_attendees_for_order(order)
 
             # return the failure message from stripe.
             return False, charge.failure_message
@@ -164,7 +164,7 @@ class TicketingManager(object):
                 save_to_db(order)
 
                 # delete related attendees to unlock the tickets
-                delete_related_attendees_for_order(db, order)
+                delete_related_attendees_for_order(order)
 
                 # return the error message from Paypal
                 return False, capture_result['L_SHORTMESSAGE0']

--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -286,7 +286,7 @@ class OrderDetail(ResourceDetail):
             send_notif_ticket_cancel(order)
 
             # delete the attendees so that the tickets are unlocked.
-            delete_related_attendees_for_order(self, order)
+            delete_related_attendees_for_order(order)
 
     def before_delete_object(self, order, view_kwargs):
         """


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5105 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Delete attendees after the order expires in order to unlock the tickets.

#### Changes proposed in this pull request:
Made the required changes.


