### PR TITLE
chore: Propage debug error information on exception for development instance

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -237,7 +237,7 @@ scheduler.start()
 
 @app.errorhandler(500)
 def internal_server_error(error):
-    if current_app.config['PROPOGATE_ERROR'] is True:
+    if current_app.config['DEVELOPMENT'] or current_app.config['PROPOGATE_ERROR']:
         exc = JsonApiException({'pointer': ''}, str(error))
     else:
         exc = JsonApiException({'pointer': ''}, 'Unknown error')


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4903 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
From the issue: 
For development instance of application, especially on obscure errors like 500, debug stack trace information should be shown to the user in the response JSON

This will severely cut down the reliance of client developers on server developers and enable them to create issues with proper data

#### Changes proposed in this pull request:
Propagate error if app configuration is `DEVELOPMENT`.