### PR TITLE
fix: HTTP 500 on oauth/facebook

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -35,8 +35,14 @@ def redirect_uri(provider):
     else:
         return make_response(jsonify(
             message="No support for {}".format(provider)), 404)
+
+    client_id = provider_class.get_client_id()
+    if not client_id:
+        return make_response(jsonify(
+            message="{} client id is not configured on the server".format(provider)), 404)
+
     url = provider_class.get_auth_uri() + '?client_id=' +\
-        provider_class.get_client_id() + '&redirect_uri=' +\
+        client_id + '&redirect_uri=' +\
         provider_class.get_redirect_uri()
     return make_response(jsonify(url=url), 200)
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5123 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
HTTP 500 when client id is not defined.

#### Changes proposed in this pull request:
Return error message instead of HTTP 500.

![500_oauth_fb](https://user-images.githubusercontent.com/21277837/42788501-759fea14-897d-11e8-8eda-7daabfa4ea6e.png)



