### PR TITLE
Fix HTTP 500 for GET user relationship of order

### DIFF
--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -319,6 +319,22 @@ class OrderRelationship(ResourceRelationship):
     """
     Order relationship
     """
+
+    def before_get(self, args, kwargs):
+        """
+        before get method to get the resource id for fetching details
+        :param view_kwargs:
+        :return:
+        """
+        if kwargs.get('order_identifier'):
+            order = safe_query(db, Order, 'identifier', kwargs['order_identifier'], 'order_identifier')
+            kwargs['id'] = order.id
+        elif kwargs.get('id'):
+            order = safe_query(db, Order, 'id', kwargs['id'], 'id')
+
+        if not has_access('is_coorganizer', event_id=order.event_id, user_id=order.user_id):
+            return ForbiddenException({'source': ''}, 'You can only access your orders or your event\'s orders')
+
     decorators = (jwt_required,)
     schema = OrderSchema
     data_layer = {'session': db.session,


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5094

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
This PR fixes the `KeyError` that is raised for getting an order's user relationship

<img width="1392" alt="screen shot 2018-07-17 at 11 13 12 pm" src="https://user-images.githubusercontent.com/22810216/42835683-02e42d4c-8a17-11e8-9de4-89bbd6b215e6.png">
