### PR TITLE
chore: update populate_db.py to add stripe keys from env file

### DIFF
--- a/populate_db.py
+++ b/populate_db.py
@@ -1,6 +1,7 @@
 from app import current_app
 from app.models import db
 from app.api.helpers.db import get_or_create  # , save_to_db
+from envparse import env
 
 # Admin message settings
 from app.api.helpers.system_mails import MAILS
@@ -66,6 +67,21 @@ def create_services():
 
 def create_settings():
     get_or_create(Setting, app_name='Open Event')
+
+    if current_app.config['DEVELOPMENT']:
+        # get the stripe keys from the env file and save it in the settings.
+        env.read_envfile()
+        stripe_secret_key = env('STRIPE_SECRET_KEY', default=None)
+        stripe_publishable_key = env('STRIPE_PUBLISHABLE_KEY', default=None)
+        stripe_client_id = env('STRIPE_CLIENT_ID', default=None)
+
+        if stripe_client_id and stripe_secret_key and stripe_publishable_key:
+            setting, _ = get_or_create(Setting, app_name='Open Event')
+            setting.stripe_client_id = stripe_client_id
+            setting.stripe_publishable_key = stripe_publishable_key
+            setting.stripe_secret_key = stripe_secret_key
+            db.session.add(setting)
+            db.session.commit()
 
 
 def create_event_image_sizes():


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5122 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Stripe test key needs to be added for testing purposes(Specially mobile developers) on the heroku deployment.

#### Changes proposed in this pull request:
Updated populate_db.py to read data from env file and add it in the db.


