### PR TITLE
fix: Allow updating deleted_at of an event

### DIFF
--- a/app/api/events.py
+++ b/app/api/events.py
@@ -444,6 +444,9 @@ class EventDetail(ResourceDetail):
             data['thumbnail_image_url'] = uploaded_images['thumbnail_image_url']
             data['icon_image_url'] = uploaded_images['icon_image_url']
 
+        if has_access('is_admin') and data.get('deleted_at') != event.deleted_at:
+            event.deleted_at = data.get('deleted_at')
+
     def after_update_object(self, event, data, view_kwargs):
         if event.state == 'published' and event.schedule_published_on:
             start_export_tasks(event)


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5144 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
The admin should be able to restore the deleted events. So changing the value of deleted events from a date to null should be possible through a patch request (only for an admin).

#### Changes proposed in this pull request:
Allow updating deleted_at for an event.


