### PR TITLE
fix: Cookie policy should be in the public schema

### DIFF
--- a/app/api/schema/settings.py
+++ b/app/api/schema/settings.py
@@ -43,6 +43,12 @@ class SettingSchemaPublic(Schema):
     # Url of Frontend
     frontend_url = fields.Url(allow_none=True)
 
+    #
+    # Cookie Policy
+    #
+    cookie_policy = fields.Str(allow_none=True)
+    cookie_policy_link = fields.Str(allow_none=True)
+
 
 class SettingSchemaNonAdmin(SettingSchemaPublic):
     """
@@ -161,9 +167,3 @@ class SettingSchemaAdmin(SettingSchemaNonAdmin):
     smtp_password = fields.Str(allow_none=True)
     smtp_port = fields.Integer(allow_none=True)
     smtp_encryption = fields.Str(allow_none=True)  # Can be tls, ssl, none
-
-    #
-    # Cookie Policy
-    #
-    cookie_policy = fields.Str(allow_none=True)
-    cookie_policy_link = fields.Str(allow_none=True)

--- a/docs/api/api_blueprint.apib
+++ b/docs/api/api_blueprint.apib
@@ -21289,8 +21289,8 @@ To update or get any attribute of this data layer, you will need admin access. H
  **Cookie Policy**
 | Parameter | Description | Type | Admin Only |
 |:----------|-------------|------|------------|
-| `cookie-policy`  | Warning to be displayed on the frontend | string | **yes** |
-| `cookie-policy-link`  | Link to the full cookie policy | string | **yes** |
+| `cookie-policy`  | Warning to be displayed on the frontend | string | - |
+| `cookie-policy-link`  | Link to the full cookie policy | string | - |
 
 ## Settings Details [/v1/settings{?page%5bsize%5d,page%5bnumber%5d,sort,filter}]
 + Parameters


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5149 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Moves `cookie_policy` and `cookie_policy_link` to public schema