### PR TITLE
fix: Allow cross origin scripting on /get-client-token endpoint

### DIFF
--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from flask import render_template, Blueprint, jsonify
+from flask_cors import cross_origin
 from flask_jwt import current_identity as current_user
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
 from marshmallow_jsonapi import fields
@@ -386,6 +387,7 @@ class ChargeList(ResourceList):
 
 
 @order_misc_routes.route('/get-client-token', methods=['GET'])
+@cross_origin()
 @jwt_required
 def send_receipt():
     """


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5171 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
When using the /get-client-token endpoint from the frontend, the server sends 404 when an OPTION request is made to the endpoint.

#### Changes proposed in this pull request:
Allowed cross origin scripting.

