### PR TITLE
fix: Add properties for paypal and stripe payment enable/disable

### DIFF
--- a/app/api/schema/settings.py
+++ b/app/api/schema/settings.py
@@ -52,6 +52,12 @@ class SettingSchemaPublic(Schema):
     cookie_policy = fields.Str(allow_none=True)
     cookie_policy_link = fields.Str(allow_none=True)
 
+    #
+    # Online Payment Flags
+    #
+    is_paypal_activated = fields.Bool(dump_only=True)
+    is_stripe_activated = fields.Bool(dump_only=True)
+
 
 class SettingSchemaNonAdmin(SettingSchemaPublic):
     """

--- a/app/models/setting.py
+++ b/app/models/setting.py
@@ -1,4 +1,5 @@
 from app.models import db
+from sqlalchemy.ext.hybrid import hybrid_property
 
 
 class Environment:
@@ -223,6 +224,19 @@ class Setting(db.Model):
         self.paypal_secret = paypal_secret
         self.paypal_sandbox_client = paypal_sandbox_client
         self.paypal_sandbox_secret = paypal_sandbox_secret
+
+    @hybrid_property
+    def is_paypal_activated(self):
+        if self.paypal_mode == 'sandbox' and self.paypal_sandbox_client and self.paypal_sandbox_secret:
+            return True
+        elif self.paypal_client and self.paypal_secret:
+            return True
+        else:
+            return False
+
+    @hybrid_property
+    def is_stripe_activated(self):
+        return self.stripe_client_id is not None
 
     def __repr__(self):
         return 'Settings'

--- a/docs/api/api_blueprint.apib
+++ b/docs/api/api_blueprint.apib
@@ -21229,6 +21229,8 @@ To update or get any attribute of this data layer, you will need admin access. H
 | `app-name`  | Name of the application (Eg. Event Yay!, Open Event) | string | - |
 | `tagline` | Tagline (Eg. Event Management and Ticketing, Home)  | string | - |
 | `secret` | App Secret  | string | **yes** |
+| `is-paypal-activated` | Whether paypal payment is configured or not | boolean | - |
+| `is-stripe-activated` | Whether stripe payment is configured or not | boolean | - |
 
 **STORAGE**
 | Parameter | Description | Type | Admin Only |
@@ -21417,7 +21419,9 @@ To update or get any attribute of this data layer, you will need admin access. H
               "static-domain": "http://example.com",
               "frontend-url": "http://example.com",
               "cookie-policy": "example",
-              "cookie-policy-link": "http://example.com"
+              "cookie-policy-link": "http://example.com",
+              "is-paypal-activated": false,
+              "is-stripe-activated": false
             },
             "type": "setting",
             "id": "1",
@@ -21557,7 +21561,9 @@ To update or get any attribute of this data layer, you will need admin access. H
               "static-domain": "http://example.com",
               "frontend-url": "http://example.com",
               "cookie-policy": "example",
-              "cookie-policy-link": "http://example.com"
+              "cookie-policy-link": "http://example.com",
+              "is-paypal-activated": false,
+              "is-stripe-activated": false
             },
             "type": "setting",
             "id": "1",


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5187 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Add properties for PayPal and stripe payment enable/disable.

#### Changes proposed in this pull request:

- Added `hybrid properties` which compute if paypal and stripe payment is activated or not. 
- These are included in the public schema so that it can be used on the frontend.


