### PR TITLE
fix: Make paid_via equal to 'card' when charging through Stripe

### DIFF
--- a/app/api/helpers/ticketing.py
+++ b/app/api/helpers/ticketing.py
@@ -104,8 +104,7 @@ class TicketingManager(object):
         # charge.paid is true if the charge succeeded, or was successfully authorized for later capture.
         if charge.paid:
             # update the order in the db.
-            order.paid_via = 'stripe'
-            order.payment_mode = charge.source.object
+            order.paid_via = charge.source.object
             order.brand = charge.source.brand
             order.exp_month = charge.source.exp_month
             order.exp_year = charge.source.exp_year


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5206 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Right now when we're charging the user through stripe, we change the payment mode to 'card' instead of changing paid_via. payment_mode should not be changed as it is used for classifying orders on the frontend.

#### Changes proposed in this pull request:
Change paid_via. 


