### PR TITLE
Fixes #5221 Admins, Sales Admin, and Marketers can't be added permanently until fields are dump_only

### DIFF
--- a/app/api/schema/users.py
+++ b/app/api/schema/users.py
@@ -51,12 +51,10 @@ class UserSchema(UserSchemaPublic):
     google_plus_url = fields.Url(allow_none=True)
     password = fields.Str(required=True, load_only=True)
     is_super_admin = fields.Boolean(dump_only=True)
-    is_admin = fields.Boolean(dump_only=True)
+    is_admin = fields.Boolean()
     facebook_id = fields.Integer(dump_only=True)
-
-    is_sales_admin = fields.Boolean(dump_only=True)
-    is_marketer = fields.Boolean(dump_only=True)
-
+    is_sales_admin = fields.Boolean()
+    is_marketer = fields.Boolean()
     is_user_organizer = fields.Boolean(dump_only=True)
     is_user_coorganizer = fields.Boolean(dump_only=True)
     is_user_track_organizer = fields.Boolean(dump_only=True)


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5221 Admins, Sales Admin, and Marketers can't be added permanently until fields are dump_only

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:

Fixes #5221 Admins, Sales Admin, and Marketers can't be added permanently until fields are dump_only

#### Changes proposed in this pull request:

- Fixes #5221 Admins, Sales Admin, and Marketers can't be added permanently until fields are dump_only