### PR TITLE
Allow bank, cheque and onsite as payment mode for orders

### DIFF
--- a/app/api/schema/orders.py
+++ b/app/api/schema/orders.py
@@ -56,8 +56,10 @@ class OrderSchema(SoftDeletionSchema):
     completed_at = fields.DateTime(dump_only=True)
     created_at = fields.DateTime(dump_only=True)
     transaction_id = fields.Str(dump_only=True)
-    payment_mode = fields.Str(default="free",
-                              validate=validate.OneOf(choices=["free", "stripe", "paypal"]), allow_none=True)
+    payment_mode = fields.Str(
+                            default="free",
+                            validate=validate.OneOf(choices=["free", "stripe", "paypal", "bank", "cheque", "onsite"]),
+                            allow_none=True)
     paid_via = fields.Str(dump_only=True)
     brand = fields.Str(dump_only=True)
     exp_month = fields.Str(dump_only=True)


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5228

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
 Currently setting bank, cheque and onsite for payment_mode returns 422 error.

#### Changes proposed in this pull request:
- Add bank, cheque and onsite as valid choices for payment Mode.