### PR TITLE
Fix error on setting is_stripe_linked field for event

### DIFF
--- a/app/api/stripe_authorization.py
+++ b/app/api/stripe_authorization.py
@@ -64,7 +64,7 @@ class StripeAuthorizationListPost(ResourceList):
         :param view_kwargs:
         :return:
         """
-        event = db.session.query(Event).filter_by(id=int(data['event']))
+        event = db.session.query(Event).filter_by(id=int(data['event'])).one()
         event.is_stripe_linked = True
         save_to_db(event)
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5231 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
 is_stripe_linked property does not set on connecting stripe account. It throws error.

#### Changes proposed in this pull request:
- Did appropriate changes to fix the error.