### PR TITLE
fix: Add check for unverified account in event update endpoint

### DIFF
--- a/app/api/events.py
+++ b/app/api/events.py
@@ -419,12 +419,18 @@ class EventDetail(ResourceDetail):
 
     def before_patch(self, args, kwargs, data=None):
         """
-        before patch method to verify if the event location is provided before publishing the event
+        before patch method to verify if the event location is provided before publishing the event and checks that
+        the user is verified
         :param args:
         :param kwargs:
         :param data:
         :return:
         """
+        is_verified = current_identity.is_verified
+        if data.get('state', None) == 'published' and not is_verified:
+            raise ForbiddenException({'source': ''},
+                                     "Only verified accounts can publish events")
+
         if data.get('state', None) == 'published' and not data.get('location_name', None):
             raise ConflictException({'pointer': '/data/attributes/location-name'},
                                     "Location is required to publish the event")
@@ -465,7 +471,8 @@ class EventDetail(ResourceDetail):
                   'model': Event,
                   'methods': {
                       'before_update_object': before_update_object,
-                      'after_update_object': after_update_object
+                      'after_update_object': after_update_object,
+                      'before_patch': before_patch
                   }}
 
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5235 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Add a check for an unverified account in event update endpoint

#### Changes proposed in this pull request:

- Ensures that the user account is verified before publishing the event.