### PR TITLE
fix: Allow event organizer to send order receipts

### DIFF
--- a/app/api/attendees.py
+++ b/app/api/attendees.py
@@ -203,8 +203,10 @@ class AttendeeRelationshipOptional(ResourceRelationship):
 @attendee_misc_routes.route('/attendees/send-receipt', methods=['POST'])
 @jwt_required
 def send_receipt():
-    # Function to send receipts to attendees related to the provided order.
-
+    """
+    Send receipts to attendees related to the provided order.
+    :return:
+    """
     order_identifier = request.json.get('order-identifier')
     if order_identifier:
         try:
@@ -212,9 +214,9 @@ def send_receipt():
         except NoResultFound:
             raise ObjectNotFound({'parameter': '{identifier}'}, "Order not found")
 
-        if order.user_id != current_identity.id:
+        if (order.user_id != current_identity.id) and (not has_access('is_registrar', event_id=order.event_id)):
             abort(
-                make_response(jsonify(error="You cannot send reciept for an order not created by you"), 403)
+                make_response(jsonify(error="You need to be the event organizer or order buyer to send receipts."), 403)
             )
         elif order.status != 'completed':
             abort(

--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -394,7 +394,7 @@ class ChargeList(ResourceList):
 
 @order_misc_routes.route('/orders/<string:order_identifier>/create-paypal-payment', methods=['POST'])
 @jwt_required
-def create_payment_payment(order_identifier):
+def create_paypal_payment(order_identifier):
     """
     Create a paypal payment.
     :return: The payment id of the created payment.


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5237 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
When the send-receipt api for orders is called from the orga app, error code 403 is thrown i.e HTTP 403 FORBIDDEN. Even though I am the organizer and I have created the order, I am not able to send the receipt.

#### Changes proposed in this pull request:
Allow the event organizer to send the order receipt.
Fixed a small typo.


