### PR TITLE
feat: Return Notification actions as relationship rather than embedded list

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -120,6 +120,8 @@ api.route(NotificationList, 'notification_list', '/users/<int:user_id>/notificat
 api.route(NotificationDetail, 'notification_detail', '/notifications/<int:id>')
 api.route(NotificationRelationship, 'notification_user',
           '/notifications/<int:id>/relationships/user')
+api.route(NotificationRelationship, 'notification_actions',
+          '/notifications/<int:id>/relationships/actions')
 
 # email_notifications
 api.route(EmailNotificationListAdmin, 'email_notification_list_admin', '/email-notifications')

--- a/app/api/schema/notifications.py
+++ b/app/api/schema/notifications.py
@@ -14,7 +14,7 @@ class NotificationActionSchema(SoftDeletionSchema):
         """
         Meta class for Notification Action API schema
         """
-        type_ = 'notification_action'
+        type_ = 'notification-action'
         inflect = dasherize
 
     id = fields.Str(dump_only=True)
@@ -44,7 +44,10 @@ class NotificationSchema(SoftDeletionSchema):
     received_at = fields.DateTime(dump_only=True)
     accept = fields.Str(allow_none=True, dump_only=True)
     is_read = fields.Boolean()
-    actions = fields.List(cls_or_instance=fields.Nested(NotificationActionSchema), allow_none=True, dump_only=True)
+    actions = Relationship(attribute='actions',
+                           schema='NotificationActionSchema',
+                           many=True,
+                           type_='notification-action')
     user = Relationship(attribute='user',
                         self_view='v1.notification_user',
                         self_view_kwargs={'id': '<id>'},

--- a/docs/api/api_blueprint.apib
+++ b/docs/api/api_blueprint.apib
@@ -16182,7 +16182,6 @@ Notifications related to the various users about invites, ticket purchase, sessi
 | `message` | Message/content of the notification | string | - |
 | `is-read` | Yes/No for read notification | boolean (default: `false`) | - |
 | `received-at` | Notification recieved time | ISO 8601 (tz-aware) | - |
-| `actions` | Notification actions | list | - |
 
 ## Notifications Collection [/v1/users/{user_id}/notifications{?page%5bsize%5d,page%5bnumber%5d,sort,filter}]
 + Parameters
@@ -16224,8 +16223,7 @@ Get a list of Notifications.
                         "received-at": "2017-06-23T04:40:37.239724+00:00",
                         "is-read": false,
                         "title": "example",
-                        "deleted-at": null,
-                        "actions": []
+                        "deleted-at": null
                     },
                     "type": "notification",
                     "id": "1",
@@ -16281,8 +16279,7 @@ Get a list of Notifications.
                         "message": "example",
                         "received-at": "2017-06-23T04:40:37.239724+00:00",
                         "is-read": false,
-                        "title": "example",
-                        "actions": []
+                        "title": "example"
                     },
                     "type": "notification",
                     "id": "1",
@@ -16302,7 +16299,7 @@ Get a list of Notifications.
 
 ## Notification Detail [/v1/notifications/{notification_id}]
 + Parameters
-    + notification_id: 1 (integer) - ID of the notifcaiton in the form of an integer
+    + notification_id: 1 (integer) - ID of the notification in the form of an integer
 
 ### Notification Detail [GET]
 Get a single notification.
@@ -16332,8 +16329,7 @@ Get a single notification.
                     "received-at": "2017-06-23T04:40:37.239724+00:00",
                     "is-read": false,
                     "deleted-at": null,
-                    "title": "example",
-                    "actions": []
+                    "title": "example"
                 },
                 "type": "notification",
                 "id": "1",
@@ -16368,8 +16364,7 @@ Update a single notification with `id`.
                 "attributes": {
                   "title": "example1",
                   "message": "example1",
-                  "is-read": "true",
-                  "actions": []
+                  "is-read": "true"
                 },
                 "type": "notification",
                 "id": "1"
@@ -16393,8 +16388,7 @@ Update a single notification with `id`.
                     "received-at": "2017-06-23T04:40:37.239724+00:00",
                     "is-read": true,
                     "deleted-at": null,
-                    "title": "example1",
-                    "actions": []
+                    "title": "example1"
                 },
                 "type": "notification",
                 "id": "1",
@@ -16430,6 +16424,66 @@ Delete a single notification.
           "jsonapi": {
             "version": "1.0"
           }
+        }
+
+
+## Notification Detail with Actions [/v1/notifications/{notification_id}?include=actions]
++ Parameters
+    + notification_id: 1 (integer) - ID of the notification in the form of an integer
+
+### Notification Detail with Actions [GET]
+Get a single notification and it's associated actions.
+
++ Request
+
+    + Headers
+
+            Accept: application/vnd.api+json
+
+            Authorization: JWT <Auth Key>
+
++ Response 200 (application/vnd.api+json)
+
+        {
+            "data": {
+                "relationships": {
+                    "user": {
+                        "links": {
+                            "self": "/v1/notifications/1/relationships/user",
+                            "related": "/v1/notifications/1/user"
+                        }
+                    }
+                },
+                "attributes": {
+                    "message": "example",
+                    "received-at": "2017-06-23T04:40:37.239724+00:00",
+                    "is-read": false,
+                    "deleted-at": null,
+                    "title": "example"
+                },
+                "type": "notification",
+                "id": "1",
+                "links": {
+                    "self": "/v1/notifications/1"
+                }
+            },
+            "included": [
+                {
+                    "type": "notification-action",
+                    "attributes": {
+                        "action-type": "view",
+                        "subject-id": "1",
+                        "subject": "event"
+                    },
+                    "id": "1"
+                }
+            ],
+            "jsonapi": {
+                "version": "1.0"
+            },
+            "links": {
+                "self": "/v1/notifications/1"
+            }
         }
 
 # Group Email Notifications

--- a/tests/hook_main.py
+++ b/tests/hook_main.py
@@ -2030,6 +2030,24 @@ def notification_get_detail(transaction):
         db.session.commit()
 
 
+@hooks.before("Notifications > Notification Detail with Actions > Notification Detail with Actions")
+def notification_get_detail_with_actions(transaction):
+    """
+    GET /notifications/1?include=actions
+    :param transaction:
+    :return:
+    """
+    with stash['app'].app_context():
+        notification_action = NotificationActionFactory()
+        db.session.add(notification_action)
+        db.session.commit()
+
+        notification = NotificationFactory()
+        notification.actions = [notification_action]
+        db.session.add(notification)
+        db.session.commit()
+
+
 @hooks.before("Notifications > Notification Detail > Update Notification")
 def notification_patch(transaction):
     """


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5259 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Right now the notification actions as sent as an embedded list rather than as a relationship. The JSON API spec doesn't specify clearly about embedded lists and hence we should switch to actions as a relationship.

#### Changes proposed in this pull request:
Return it as a relationship which can be easily serialized by the frontend and is according to JSON API spec.



