### PR TITLE
fix typo in type of event_role_permission api

### DIFF
--- a/app/api/schema/event_role_permissions.py
+++ b/app/api/schema/event_role_permissions.py
@@ -15,7 +15,7 @@ class EventsRolePermissionSchema(Schema):
         """
         Meta class for Notification API schema
         """
-        type_ = 'event-role-permissions'
+        type_ = 'event-role-permission'
         self_view = 'v1.events_role_detail'
         self_view_kwargs = {'id': '<id>'}
         self_view_many = 'v1.events_role_list'


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5236 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
type in schema of event_role_permission api should be event-role-permission not event-role-permissions