### PR TITLE
Use order_expiry_time to expire the orders

### DIFF
--- a/app/api/helpers/order.py
+++ b/app/api/helpers/order.py
@@ -38,7 +38,7 @@ def set_expiry_for_order(order, override=False):
     """
     if order and not order.paid_via and (override or (order.status == 'pending' and (
                 order.created_at +
-                timedelta(minutes=ticketing.TicketingManager.get_order_expiry())) < datetime.now(timezone.utc))):
+                timedelta(minutes=order.event.order_expiry_time)) < datetime.now(timezone.utc))):
             order.status = 'expired'
             delete_related_attendees_for_order(order)
             save_to_db(order)

--- a/tests/unittests/api/helpers/test_order.py
+++ b/tests/unittests/api/helpers/test_order.py
@@ -5,6 +5,7 @@ from app import current_app as app, db
 from app.api.helpers import ticketing
 from app.api.helpers.order import set_expiry_for_order, delete_related_attendees_for_order
 from app.factories.attendee import AttendeeFactory
+from app.factories.event import EventFactoryBasic
 from app.factories.order import OrderFactory
 from app.models.order import Order
 from tests.unittests.setup_database import Setup
@@ -18,14 +19,18 @@ class TestOrderUtilities(OpenEventTestCase):
     def test_should_expire_outdated_order(self):
         with app.test_request_context():
             obj = OrderFactory()
+            event = EventFactoryBasic()
+            obj.event = event
             obj.created_at = datetime.now(timezone.utc) - timedelta(
-                minutes=ticketing.TicketingManager.get_order_expiry() + 10)
+                minutes=obj.event.order_expiry_time)
             set_expiry_for_order(obj)
             self.assertEqual(obj.status, 'expired')
 
     def test_should_not_expire_valid_orders(self):
         with app.test_request_context():
             obj = OrderFactory()
+            event = EventFactoryBasic()
+            obj.event = event
             set_expiry_for_order(obj)
             self.assertEqual(obj.status, 'pending')
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5265 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
 Currently we are expiring orders after 10 minutes. We should change it to order_expiry_time parameter.

#### Changes proposed in this pull request:
Use `order_expiry_time` as parameter to expire orders