### PR TITLE
fix: Raise proper exception when paypal keys are absent

### DIFF
--- a/app/api/helpers/payment.py
+++ b/app/api/helpers/payment.py
@@ -139,14 +139,14 @@ class PayPalPaymentsManager(object):
         # Use Sandbox by default.
         settings = get_settings()
         paypal_mode = 'sandbox'
-        paypal_client = settings['paypal_sandbox_client']
-        paypal_secret = settings['paypal_sandbox_secret']
+        paypal_client = settings.get('paypal_sandbox_client', None)
+        paypal_secret = settings.get('paypal_sandbox_secret', None)
 
         # Switch to production if paypal_mode is production.
         if settings['paypal_mode'] == Environment.PRODUCTION:
             paypal_mode = 'live'
-            paypal_client = settings['paypal_client']
-            paypal_secret = settings['paypal_secret']
+            paypal_client = settings.get('paypal_client', None)
+            paypal_secret = settings.get('paypal_secret', None)
 
         if not paypal_client or not paypal_secret:
             raise ConflictException({'pointer': ''}, "Payments through Paypal hasn't been configured on the platform")


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5272 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Raise conflict exception when paypal keys aren't added on the server.

#### Changes proposed in this pull request:
Raise conflict exception when paypal keys aren't added on the server.


