### PR TITLE
fix: Internal server error while creating a normal user's speaker

### DIFF
--- a/app/api/speakers.py
+++ b/app/api/speakers.py
@@ -21,7 +21,7 @@ class SpeakerListPost(ResourceList):
     List and create speakers
     """
 
-    def before_post(self, args, kwargs, data):
+    def before_post(self, args, kwargs, data=None):
         """
         method to add user_id to view_kwargs before post
         :param args:
@@ -32,10 +32,10 @@ class SpeakerListPost(ResourceList):
         require_relationship(['event', 'user'], data)
 
         if not has_access('is_coorganizer', event_id=data['event']):
-                event = safe_query(self, Event, 'id', data['event'], 'event_id')
-                if event.state == "draft":
-                    raise ObjectNotFound({'parameter': 'event_id'},
-                                         "Event: {} not found".format(data['event_id']))
+            event = db.session.query(Event).filter_by(id=data['event']).one()
+            if event.state == "draft":
+                raise ObjectNotFound({'parameter': 'event_id'},
+                                     "Event: {} not found".format(data['event_id']))
 
         if get_count(db.session.query(Event).filter_by(id=int(data['event']), is_sessions_speakers_enabled=False)) > 0:
             raise ForbiddenException({'pointer': ''}, "Speakers are disabled for this Event")


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5282 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Now the speaker is successfully created.

#### Changes proposed in this pull request:

- Directly use db.session as before_post method doesn't support passing it via self.