### PR TITLE
fix: Disallow creating users with same email

### DIFF
--- a/app/api/users.py
+++ b/app/api/users.py
@@ -44,7 +44,7 @@ class UserList(ResourceList):
         :param view_kwargs:
         :return:
         """
-        if db.session.query(User.id).filter_by(email=data['email'], deleted_at=None).scalar() is not None:
+        if db.session.query(User.id).filter_by(email=data['email']).scalar() is not None:
             raise ConflictException({'pointer': '/data/attributes/email'}, "Email already exists")
 
     def after_create_object(self, user, data, view_kwargs):


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5278 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
If we soft-delete a user account and try to create an account with the same email again, the server used to allow creating it but sends HTTP 500 when doing so since it voilates the unique constraint in the db.