### PR TITLE
Fixes 5354 Adds docstring to unittests

### DIFF
--- a/tests/unittests/api/helpers/test_db.py
+++ b/tests/unittests/api/helpers/test_db.py
@@ -17,6 +17,8 @@ class TestDBHelperValidation(OpenEventTestCase):
         self.app = Setup.create_app()
 
     def test_save_to_db(self):
+        """Method to test the function save_to_db"""
+
         with app.test_request_context():
             obj = EventFactoryBasic()
             save_to_db(obj)
@@ -24,6 +26,8 @@ class TestDBHelperValidation(OpenEventTestCase):
             self.assertEqual(obj.name, event.name)
 
     def test_safe_query(self):
+        """Method to test the function safe_query"""
+
         with app.test_request_context():
             event = EventFactoryBasic()
             db.session.add(event)
@@ -32,10 +36,14 @@ class TestDBHelperValidation(OpenEventTestCase):
             self.assertEqual(obj.name, event.name)
 
     def test_safe_query_exception(self):
+        """Method to test the exception in function safe_query"""
+
         with app.test_request_context():
             self.assertRaises(ObjectNotFound, lambda: safe_query(db, Event, 'id', 1, 'event_id'))
 
     def test_get_or_create(self):
+        """Method to test the function get_or_create"""
+
         with app.test_request_context():
             event = EventFactoryBasic()
             save_to_db(event)
@@ -48,6 +56,8 @@ class TestDBHelperValidation(OpenEventTestCase):
             self.assertTrue(is_created)
 
     def test_get_count(self):
+        """Method to test the number of queries concerning a Model"""
+
         with app.test_request_context():
             attendee = AttendeeFactory()
             save_to_db(attendee)

--- a/tests/unittests/api/helpers/test_errors.py
+++ b/tests/unittests/api/helpers/test_errors.py
@@ -12,6 +12,8 @@ class TestErrorsHelperValidation(OpenEventTestCase):
         self.app = Setup.create_app()
 
     def test_errors(self):
+        """Method to test the status code of all errors."""
+
         with app.test_request_context():
             # Forbidden Error
             forbidden_error = ForbiddenError({'source': ''}, 'Super admin access is required')

--- a/tests/unittests/api/helpers/test_events.py
+++ b/tests/unittests/api/helpers/test_events.py
@@ -14,6 +14,7 @@ class TestEventUtilities(OpenEventTestCase):
         self.app = Setup.create_app()
 
     def test_should_create_attendee_forms(self):
+        """Method to test custom forms for attendees of an event."""
         with app.test_request_context():
             event = EventFactoryBasic()
             save_to_db(event)

--- a/tests/unittests/api/helpers/test_exceptions.py
+++ b/tests/unittests/api/helpers/test_exceptions.py
@@ -10,6 +10,8 @@ class TestExceptionsHelperValidation(OpenEventTestCase):
         self.app = Setup.create_app()
 
     def test_exceptions(self):
+        """Method to test all exceptions."""
+
         # Unprocessable Entity Exception
         with self.assertRaises(UnprocessableEntity):
             raise UnprocessableEntity({'pointer': '/data/attributes/min-quantity'},

--- a/tests/unittests/api/helpers/test_files.py
+++ b/tests/unittests/api/helpers/test_files.py
@@ -24,6 +24,8 @@ class TestFilesHelperValidation(OpenEventTestCase):
         return im.size
 
     def test_uploaded_image_local(self):
+        """Method to test uploading image locally"""
+
         with app.test_request_context():
             file_content = "data:image/gif;base64,\
                             R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/\
@@ -38,6 +40,7 @@ class TestFilesHelperValidation(OpenEventTestCase):
             self.assertTrue(os.path.exists(file_path))
 
     def test_upload_single_file(self):
+        """Method to test uploading of single file"""
 
         class FileObj(BytesIO):
 
@@ -69,6 +72,8 @@ class TestFilesHelperValidation(OpenEventTestCase):
             self.assertTrue(os.path.exists(file_path))
 
     def test_upload_multiple_file(self):
+        """Method to test uploading of multiple files"""
+
         class FileObj(BytesIO):
 
             def close(self):
@@ -104,6 +109,8 @@ class TestFilesHelperValidation(OpenEventTestCase):
                 self.assertTrue(os.path.exists(file_path))
 
     def test_create_save_resized_image(self):
+        """Method to test create resized images"""
+
         with app.test_request_context():
             image_url_test = 'https://cdn.pixabay.com/photo/2014/09/08/17/08/hot-air-balloons-439331_960_720.jpg'
             width = 500
@@ -119,6 +126,8 @@ class TestFilesHelperValidation(OpenEventTestCase):
             self.assertEqual(resized_height, height)
 
     def test_create_save_image_sizes(self):
+        """Method to test create image sizes"""
+
         with app.test_request_context():
             image_url_test = 'https://cdn.pixabay.com/photo/2014/09/08/17/08/hot-air-balloons-439331_960_720.jpg'
             image_sizes_type = "event-image"

--- a/tests/unittests/api/helpers/test_jwt.py
+++ b/tests/unittests/api/helpers/test_jwt.py
@@ -16,6 +16,8 @@ class TestJWTHelperValidation(OpenEventTestCase):
         self.app = Setup.create_app()
 
     def test_jwt_authenticate(self):
+        """Method to test jwt authentication"""
+
         with app.test_request_context():
             user = UserFactory()
             db.session.add(user)
@@ -30,6 +32,8 @@ class TestJWTHelperValidation(OpenEventTestCase):
             self.assertIsNone(wrong_credential_user)
 
     def test_get_identity(self):
+        """Method to test identity of authenticated user"""
+
         with app.test_request_context():
             user = UserFactory()
             db.session.add(user)

--- a/tests/unittests/api/helpers/test_order.py
+++ b/tests/unittests/api/helpers/test_order.py
@@ -16,6 +16,8 @@ class TestOrderUtilities(OpenEventTestCase):
         self.app = Setup.create_app()
 
     def test_should_expire_outdated_order(self):
+        """Method to test expiration of outdated orders"""
+
         with app.test_request_context():
             obj = OrderFactory()
             event = EventFactoryBasic()
@@ -26,6 +28,8 @@ class TestOrderUtilities(OpenEventTestCase):
             self.assertEqual(obj.status, 'expired')
 
     def test_should_not_expire_valid_orders(self):
+        """Method to test to not mark valid orders as expired"""
+
         with app.test_request_context():
             obj = OrderFactory()
             event = EventFactoryBasic()
@@ -34,6 +38,8 @@ class TestOrderUtilities(OpenEventTestCase):
             self.assertEqual(obj.status, 'pending')
 
     def test_should_delete_related_attendees(self):
+        """Method to test to delete related attendees of an event"""
+
         with app.test_request_context():
             attendee = AttendeeFactory()
             db.session.add(attendee)

--- a/tests/unittests/api/helpers/test_permission_manager.py
+++ b/tests/unittests/api/helpers/test_permission_manager.py
@@ -31,17 +31,23 @@ class TestPermissionManager(OpenEventTestCase):
             self.auth = {'Authorization': "JWT " + str(_default_jwt_encode_handler(user), 'utf-8')}
 
     def test_has_access(self):
+        """Method to test whether user has access to different roles"""
+
         with app.test_request_context(headers=self.auth):
             self.assertTrue(has_access('is_admin'))
             self.assertFalse(has_access('is_super_admin'))
             self.assertTrue(has_access('is_organizer', event_id=1))
 
     def test_accessible_role_based_events(self):
+        """Method to test accessible role of a user based on an event"""
+
         with app.test_request_context(headers=self.auth, method="POST"):
             response = accessible_role_based_events(lambda *a, **b: b.get('user_id'), (), {}, (), {})
             assert response is not None
 
     def test_is_organizer(self):
+        """Method to test whether a user is organizer of an event or not"""
+
         with app.test_request_context(headers=self.auth, method="POST"):
             uer, is_created = get_or_create(UsersEventsRoles, user_id=1, event_id=1)
             uer.role_id = 1
@@ -49,13 +55,8 @@ class TestPermissionManager(OpenEventTestCase):
             self.assertTrue(has_access('is_organizer', event_id=1))
 
     def test_is_coorganizer(self):
-        with app.test_request_context(headers=self.auth, method="POST"):
-            uer, is_created = get_or_create(UsersEventsRoles, user_id=1, event_id=1)
-            uer.role_id = 2
-            save_to_db(uer)
-            self.assertTrue(has_access('is_coorganizer', event_id=1))
+        """Method to test whether a user is coorganizer of an event or not"""
 
-    def test_is_coorganizer_endpoint_related_to_event(self):
         with app.test_request_context(headers=self.auth, method="POST"):
             uer, is_created = get_or_create(UsersEventsRoles, user_id=1, event_id=1)
             uer.role_id = 2
@@ -63,6 +64,8 @@ class TestPermissionManager(OpenEventTestCase):
             self.assertTrue(has_access('is_coorganizer', event_id=1))
 
     def test_is_moderator(self):
+        """Method to test whether a user is moderator of an event or not"""
+
         with app.test_request_context(headers=self.auth, method="POST"):
             uer, is_created = get_or_create(UsersEventsRoles, user_id=1, event_id=1)
             uer.role_id = 4
@@ -70,6 +73,8 @@ class TestPermissionManager(OpenEventTestCase):
             self.assertTrue(has_access('is_moderator', event_id=1))
 
     def test_is_track_organizer(self):
+        """Method to test whether a user is track organizer of an event or not"""
+
         with app.test_request_context(headers=self.auth, method="POST"):
             uer, is_created = get_or_create(UsersEventsRoles, user_id=1, event_id=1)
             uer.role_id = 4
@@ -77,6 +82,8 @@ class TestPermissionManager(OpenEventTestCase):
             self.assertTrue(has_access('is_moderator', event_id=1))
 
     def test_is_registrar(self):
+        """Method to test whether a user is registrar of an event or not"""
+
         with app.test_request_context(headers=self.auth, method="POST"):
             uer, is_created = get_or_create(UsersEventsRoles, user_id=1, event_id=1)
             uer.role_id = 6
@@ -84,6 +91,8 @@ class TestPermissionManager(OpenEventTestCase):
             self.assertTrue(has_access('is_registrar', event_id=1))
 
     def test_permission_manager_attributes(self):
+        """Method to test attributes of permission manager"""
+
         with app.test_request_context():
             kwargs = {'leave_if': lambda a: True}
             perm = permission_manager(lambda *a, **b: True, [], {}, 'is_admin', **kwargs)

--- a/tests/unittests/api/helpers/test_utilities.py
+++ b/tests/unittests/api/helpers/test_utilities.py
@@ -12,6 +12,8 @@ class TestUtilitiesHelperValidation(OpenEventTestCase):
         self.app = Setup.create_app()
 
     def test_dasherize(self):
+        """Method to test whether an attribute dasherizes or not"""
+
         with app.test_request_context():
             field = "starts_at"
             dasherized_field = "starts-at"
@@ -19,6 +21,8 @@ class TestUtilitiesHelperValidation(OpenEventTestCase):
             self.assertEqual(result, dasherized_field)
 
     def test_require_relationship(self):
+        """Method to test relationship in request data"""
+
         with self.assertRaises(UnprocessableEntity):
             data = ['event']
             require_relationship(['sponsor', 'event'], data)

--- a/tests/unittests/test_migrations.py
+++ b/tests/unittests/test_migrations.py
@@ -9,6 +9,8 @@ class TestMigrations(OpenEventTestCase):
         self.app = Setup.create_app()
 
     def test_migrations(self):
+        """Method to test the database migrations"""
+
         with app.test_request_context():
             result = check_migrations().split(',')
             self.assertEqual(result[0], 'success')


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes 5354 Adds docstring to unittests

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:

Fixes 5354 Adds docstring to unittests

#### Changes proposed in this pull request:

- Fixes 5354 Adds docstring to unittests

![screenshot from 2018-08-14 20-22-23](https://user-images.githubusercontent.com/22936570/44099389-249584d2-a000-11e8-80d9-8f820ce9a7b8.png)
