### PR TITLE
Pass redis as backend while initialising celery

### DIFF
--- a/app/views/celery_.py
+++ b/app/views/celery_.py
@@ -1,4 +1,4 @@
 from celery import Celery
 from config import Config
 
-celery = Celery(__name__, broker=Config.REDIS_URL)
+celery = Celery(__name__, broker=Config.REDIS_URL, backend=Config.CELERY_BACKKEND)

--- a/config.py
+++ b/config.py
@@ -59,6 +59,7 @@ class Config(object):
     ENABLE_ELASTICSEARCH = env.bool('ENABLE_ELASTICSEARCH', default=False)
     ELASTICSEARCH_HOST = env('ELASTICSEARCH_HOST', default='localhost:9200')
     REDIS_URL = env('REDIS_URL', default='redis://localhost:6379/0')
+    CELERY_BACKKEND = env('CELERY_BACKEND', default='redis')
 
     # API configs
     SOFT_DELETE = True


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Passes Redis as backend during initialisation to prevent failure of event exports.
Exports on frontend start working(tested locally)