### PR TITLE
Adds the Missing initialisation in models/event_orga.py

### DIFF
--- a/app/models/event_orga.py
+++ b/app/models/event_orga.py
@@ -1,6 +1,6 @@
 from app.models import db
 from app.models.base import SoftDeletionModel
-
+from datetime import datetime
 
 class EventOrgaModel(SoftDeletionModel):
     """Event Orga object table"""
@@ -13,9 +13,12 @@ class EventOrgaModel(SoftDeletionModel):
     payment_currency = db.Column(db.String, nullable=False)
 
     def __init__(self,
-                 name=None):
+                 name=None,
+                 payment_currency=None):
 
         self.name = name
+        self.starts_at = datetime.utcnow()
+        self.payment_currency = payment_currency
 
     def __repr__(self):
         return '<EventOrgaModel %r>' % self.name


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5397 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
In models/event_orga.py, initialisation of `starts_at` and `payment_currency` were missing.

#### Changes proposed in this pull request:

- adds the required initialisation values of `starts_at` and `payment_currency` variables

