### PR TITLE
Lax permissions to view discount codes

### DIFF
--- a/app/api/discount_codes.py
+++ b/app/api/discount_codes.py
@@ -222,10 +222,12 @@ class DiscountCodeDetail(ResourceDetail):
                 raise ObjectNotFound(
                     {'parameter': '{id}'}, "DiscountCode: not found")
 
-            if discount.used_for == 'ticket' and has_access('is_coorganizer', event_id=discount.event_id):
+#             if discount.used_for == 'ticket' and has_access('is_coorganizer', event_id=discount.event_id):
+            if discount.used_for == 'ticket':
                 self.schema = DiscountCodeSchemaTicket
 
-            elif discount.used_for == 'event' and has_access('is_admin'):
+#             elif discount.used_for == 'event' and has_access('is_admin'):
+            elif discount.used_for == 'event':
                 self.schema = DiscountCodeSchemaEvent
             else:
                 raise UnprocessableEntity({'source': ''},
@@ -267,10 +269,12 @@ class DiscountCodeDetail(ResourceDetail):
                 self.schema = DiscountCodeSchemaPublic
                 return
 
-            if discount.used_for == 'ticket' and has_access('is_coorganizer', event_id=discount.event_id):
+#             if discount.used_for == 'ticket' and has_access('is_coorganizer', event_id=discount.event_id):
+            if discount.used_for == 'ticket':
                 self.schema = DiscountCodeSchemaTicket
 
-            elif discount.used_for == 'event' and has_access('is_admin'):
+#             elif discount.used_for == 'event' and has_access('is_admin'):
+            elif discount.used_for == 'event':
                 self.schema = DiscountCodeSchemaEvent
             else:
                 raise UnprocessableEntity({'source': ''},
@@ -319,7 +323,7 @@ class DiscountCodeDetail(ResourceDetail):
         else:
             raise UnprocessableEntity({'source': ''}, "Please verify your permission")
 
-    decorators = (jwt_required,)
+#     decorators = (jwt_required,)
     schema = DiscountCodeSchemaTicket
     data_layer = {'session': db.session,
                   'model': DiscountCode,


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5550 


#### Short description of what this resolves:

- Relaxes permissions to make GET requests to discount codes so that not logged in users are able to use them.


