### PR TITLE
Event model: Add info about presence of sessions,speakers

### DIFF
--- a/app/api/schema/events.py
+++ b/app/api/schema/events.py
@@ -82,6 +82,8 @@ class EventSchemaPublic(SoftDeletionSchema):
     organizer_name = fields.Str(allow_none=True)
     is_map_shown = fields.Bool(default=False)
     has_organizer_info = fields.Bool(default=False)
+    has_sessions = fields.Bool(default=0, dump_only=True)
+    has_speakers = fields.Bool(default=0, dump_only=True)
     organizer_description = fields.Str(allow_none=True)
     is_sessions_speakers_enabled = fields.Bool(default=False)
     privacy = fields.Str(default="public")

--- a/app/models/event.py
+++ b/app/models/event.py
@@ -18,6 +18,8 @@ from app.models.feedback import Feedback
 from app.models.helpers.versioning import clean_up_string, clean_html
 from app.models.user import ATTENDEE, ORGANIZER
 from app.models.event_topic import EventTopic
+from app.models.session import Session
+from app.models.speaker import Speaker
 from app.models.search import sync
 from app.models.ticket import Ticket
 from app.models.ticket_holder import TicketHolder
@@ -379,6 +381,15 @@ class Event(SoftDeletionModel):
     @property
     def revenue(self):
         return self.calc_revenue()
+
+    @property
+    def has_sessions(self):
+        return Session.query.filter_by(event_id=self.id).count() > 0
+
+    @property
+    def has_speakers(self):
+        return Speaker.query.filter_by(event_id=self.id).count() > 0
+
 
 
 @event.listens_for(Event, 'after_update')


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5529 


#### Short description of what this resolves:
Eliminates the need to fetch all sessions and speakers of an event just to check if they exist.

#### Changes proposed in this pull request:

- Add field `has_sessions` to the event model
- Add field `has_speakers` to the event model





