### PR TITLE
List sessions for user where user is a speaker but not creator

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -87,7 +87,8 @@ class SessionList(ResourceList):
             query_ = query_.join(Microlocation).filter(Microlocation.id == microlocation.id)
         if view_kwargs.get('user_id') is not None:
             user = safe_query(self, User, 'id', view_kwargs['user_id'], 'user_id')
-            query_ = query_.join(User).filter(User.id == user.id)
+            query_ = query_.join(User)\
+                .join(Speaker).filter((User.id == user.id or Session.speakers.any(Speaker.user_id == user.id)))
         query_ = event_query(self, query_, view_kwargs)
         if view_kwargs.get('speaker_id'):
             speaker = safe_query(self, Speaker, 'id', view_kwargs['speaker_id'], 'speaker_id')


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5567 

#### Short description of what this resolves:
A major bug which does not associate sessions to a user if he is not the creator of the session. This is because users are queried via only the `creator_id`



