### PR TITLE
Make it possible to delete expired orders

### DIFF
--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -315,8 +315,7 @@ class OrderDetail(ResourceDetail):
 
     # This is to ensure that the permissions manager runs and hence changes the kwarg from order identifier to id.
     decorators = (jwt_required, api.has_permission(
-        'auth_required', methods="PATCH,DELETE", fetch="user_id", model=Order),)
-
+        'auth_required', methods="PATCH,DELETE", model=Order),)
     schema = OrderSchema
     data_layer = {'session': db.session,
                   'model': Order,


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5569 


#### Short description of what this resolves:

The redundant fetch arg made it possible to delete the session only if the creator of the order was authenticated. It prevented the event organizers and co-organizers from deleting the order.

