### PR TITLE
Prevent user from becoming admin after DELETE request

### DIFF
--- a/app/api/users.py
+++ b/app/api/users.py
@@ -208,7 +208,7 @@ class UserDetail(ResourceDetail):
             else:
                 raise ConflictException({'pointer': '/data/attributes/email'}, "Email already exists")
 
-        if has_access('is_super_admin') and data.get('is_admin') != user.is_admin:
+        if has_access('is_super_admin') and data.get('is_admin') and data.get('is_admin') != user.is_admin:
             user.is_admin = not user.is_admin
 
         if has_access('is_admin') and data.get('is_sales_admin') != user.is_sales_admin:


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5591 



#### Short description of what this resolves:
This PR prevents the user from being given a role of Admin, when the user is deleted. It was occurring due to an invalid comparison with null.

