### PR TITLE
Ensuring that deleted events are separated from admin statistics

### DIFF
--- a/app/api/schema/admin_statistics_schema/events.py
+++ b/app/api/schema/admin_statistics_schema/events.py
@@ -26,11 +26,11 @@ class AdminStatisticsEventSchema(Schema):
 
     def events_draft_count(self, obj):
         events = Event.query.filter(Event.ends_at > datetime.now(pytz.utc))
-        return get_count(events.filter_by(state='draft'))
+        return get_count(events.filter_by(state='draft', deleted_at=None))
 
     def events_published_count(self, obj):
         events = Event.query.filter(Event.ends_at > datetime.now(pytz.utc))
-        return get_count(events.filter_by(state='published'))
+        return get_count(events.filter_by(state='published', deleted_at=None))
 
     def events_past_count(self, obj):
         return get_count(Event.query.filter(Event.ends_at < datetime.now(pytz.utc)))


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5604 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:

It makes sure that the events that have been deleted are not included in any event category (`published` or `draft`)

#### Changes proposed in this pull request:

- Setting `deleted_at=None` for query param

#### Admin Panel post changes
![image](https://user-images.githubusercontent.com/21087061/52662580-9a937e00-2f2a-11e9-933f-9a983f92a699.png)
