### PR TITLE
fix: Custom Form model initialisation

### DIFF
--- a/app/models/custom_form.py
+++ b/app/models/custom_form.py
@@ -88,11 +88,11 @@ class CustomForms(SoftDeletionModel):
                  is_fixed=None,
                  deleted_at=None):
         self.event_id = event_id
-        self.field_identifier = field_identifier,
-        self.form = form,
-        self.type = type,
-        self.is_required = is_required,
-        self.is_included = is_included,
+        self.field_identifier = field_identifier
+        self.form = form
+        self.type = type
+        self.is_required = is_required
+        self.is_included = is_included
         self.is_fixed = is_fixed
         self.deleted_at = deleted_at
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5622 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:

It fixes the initialisation of the custom form model which is initially rigged with ','

Please see this discussion to know why the stack trace was reported as such 
https://github.com/spotify/luigi/issues/2347#issuecomment-388724671 
#### Changes proposed in this pull request:

- Removing commas from end of `self.var=var` statements

