### PR TITLE
fix : ensure distinct organisers in no. of organisers

### DIFF
--- a/app/api/admin_statistics_api/users.py
+++ b/app/api/admin_statistics_api/users.py
@@ -12,7 +12,6 @@ from app.models.users_events_role import UsersEventsRoles
 from app.models.role import Role
 from app.api.helpers.db import get_count
 
-
 class AdminStatisticsUserSchema(Schema):
     """
     Api schema
@@ -49,21 +48,21 @@ class AdminStatisticsUserSchema(Schema):
 
     def get_all_user_roles(self, role_name):
         role = Role.query.filter_by(name=role_name).first()
-        uers = UsersEventsRoles.query.join(UsersEventsRoles.event).join(UsersEventsRoles.role).filter(
-            Event.deleted_at.is_(None), UsersEventsRoles.role == role)
-        return uers
+        newquery = User.query.join(UsersEventsRoles.user).join(UsersEventsRoles.role).filter(
+            UsersEventsRoles.role == role).distinct()
+        return newquery
 
     def organizer_count(self, obj):
-        return get_count(self.get_all_user_roles('organizer'))
+        return self.get_all_user_roles('organizer').count()
 
     def coorganizer_count(self, obj):
-        return get_count(self.get_all_user_roles('coorganizer'))
+        return self.get_all_user_roles('coorganizer').count()
 
     def track_organizer_count(self, obj):
-        return get_count(self.get_all_user_roles('track_organizer'))
+        return self.get_all_user_roles('track_organizer').count()
 
     def attendee_count(self, obj):
-        return get_count(self.get_all_user_roles('attendee'))
+        return self.get_all_user_roles('attendee').count()
 
 
 class AdminStatisticsUserDetail(ResourceDetail):


### PR DESCRIPTION

<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5631 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
It makes sure that distinct users on a particular role are being counted instead of the whole query result

#### Changes proposed in this pull request:

- Creating a local helper to give the length of distinct users on an event role
- Using that helper instead of get_count helper

![image](https://user-images.githubusercontent.com/21087061/53127986-bed60700-3589-11e9-9b44-a4e712585d02.png)

