### PR TITLE
fix: the file upload helper tests for uploading single and multiple files

### DIFF
--- a/tests/all/integration/api/helpers/test_files.py
+++ b/tests/all/integration/api/helpers/test_files.py
@@ -64,7 +64,7 @@ class TestFilesHelperValidation(OpenEventTestCase):
         with app.test_request_context():
             client = app.test_client()
             resp = client.post('/test_upload', data={'file': (BytesIO(b'1,2,3,4'), 'test_file.csv')})
-            data = json.loads(resp.data)
+            data = resp.get_json()
             file_path = data['path']
             filename = data['name']
             actual_file_path = app.config.get('BASE_DIR') + '/static/uploads/' + filename
@@ -100,7 +100,7 @@ class TestFilesHelperValidation(OpenEventTestCase):
             resp = client.post('/test_upload_multi',
                                data={'files[]': [(BytesIO(b'1,2,3,4'), 'test_file.csv'),
                                                  (BytesIO(b'10,20,30,40'), 'test_file2.csv')]})
-            datas = json.loads(resp.data)['files']
+            datas = resp.get_json()['files']
             for data in datas:
                 file_path = data['path']
                 filename = data['name']


### PR DESCRIPTION
Fixes #5633 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->

#### Short description of what this resolves:
Earlier, a bytes data was being passed to json.dumps, however json.dumps expects a string object. Now, `flask.json.jsonify.get_json()` is being used which directly returns a dict object.