### PR TITLE
fix: prevent deleted users from logging in

### DIFF
--- a/app/api/helpers/jwt.py
+++ b/app/api/helpers/jwt.py
@@ -14,7 +14,7 @@ def jwt_authenticate(email, password):
     :param password:
     :return:
     """
-    user = User.query.filter_by(email=email).first()
+    user = User.query.filter_by(email=email, deleted_at=None).first()
     if user is None:
         return None
     auth_ok = user.facebook_login_hash == password or check_password_hash(

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -78,7 +78,6 @@ class User(SoftDeletionModel):
     was_registered_with_order = db.Column(db.Boolean, default=False)
     last_accessed_at = db.Column(db.DateTime(timezone=True))
     created_at = db.Column(db.DateTime(timezone=True), default=datetime.now(pytz.utc))
-    deleted_at = db.Column(db.DateTime(timezone=True), default=None)
     speaker = db.relationship('Speaker', backref="user")
     favourite_events = db.relationship('UserFavouriteEvent', backref="user")
     session = db.relationship('Session', backref="user")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -78,6 +78,7 @@ class User(SoftDeletionModel):
     was_registered_with_order = db.Column(db.Boolean, default=False)
     last_accessed_at = db.Column(db.DateTime(timezone=True))
     created_at = db.Column(db.DateTime(timezone=True), default=datetime.now(pytz.utc))
+    deleted_at = db.Column(db.DateTime(timezone=True), default=None)
     speaker = db.relationship('Speaker', backref="user")
     favourite_events = db.relationship('UserFavouriteEvent', backref="user")
     session = db.relationship('Session', backref="user")


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes fossasia/open-event-frontend#2216

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
It adds a utilisation of  default `deleted_at` attribute to the User model and in the authentication query, makes sure that deleted_at is `None`

#### Changes proposed in this pull request:

- setting the field to None and querying for the same

