### PR TITLE
Change method used for password validation in jwt_authenticate

### DIFF
--- a/app/api/helpers/jwt.py
+++ b/app/api/helpers/jwt.py
@@ -17,11 +17,7 @@ def jwt_authenticate(email, password):
     user = User.query.filter_by(email=email, deleted_at=None).first()
     if user is None:
         return None
-    auth_ok = user.facebook_login_hash == password or check_password_hash(
-        password.encode('utf-8'),
-        user.password.encode('utf-8'),
-        user.salt
-    )
+    auth_ok = user.facebook_login_hash == password or user.is_correct_password(password)
     if auth_ok:
         return user
     else:


### PR DESCRIPTION
Fixes: #5646

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->

#### Short description of what this resolves:
jwt_authenticate function currently uses check_password_hash to validate password while
a User class method exists for the same. Therefore to increase consistency in the code
we should replace check_password_hash with is_correct_password (instance method of User class).