### PR TITLE
fix: use ticket holders for admin attendee count

### DIFF
--- a/app/api/admin_statistics_api/users.py
+++ b/app/api/admin_statistics_api/users.py
@@ -10,6 +10,7 @@ from app.api.data_layers.NoModelLayer import NoModelLayer
 from app.models.event import Event
 from app.models.users_events_role import UsersEventsRoles
 from app.models.role import Role
+from app.models.ticket_holder import TicketHolder
 from app.api.helpers.db import get_count
 
 class AdminStatisticsUserSchema(Schema):
@@ -62,7 +63,8 @@ class AdminStatisticsUserSchema(Schema):
         return self.get_all_user_roles('track_organizer').count()
 
     def attendee_count(self, obj):
-        return self.get_all_user_roles('attendee').count()
+        unique_attendee_query = db.session.query(TicketHolder.email).distinct()
+        return unique_attendee_query.count()
 
 
 class AdminStatisticsUserDetail(ResourceDetail):


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5645 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
I am utilising unique ticket holder count instead of the "attendee" role of UserEventRole model 

#### Changes proposed in this pull request:

- using unique Ticket Holders for attendee count


