### PR TITLE
fix : use event identifier in session link

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -51,8 +51,9 @@ class SessionListPost(ResourceList):
             organizer = session.event.get_organizer()
             organizer_email = organizer.email
             frontend_url = get_settings()['frontend_url']
+            event = session.event
             link = "{}/events/{}/sessions/{}"\
-                .format(frontend_url, session.event_id, session.id)
+                .format(frontend_url, event.identifier, session.id)
             send_email_new_session(organizer_email, event_name, link)
             send_notif_new_session_organizer(organizer, event_name, link, session.id)
 
@@ -126,12 +127,14 @@ class SessionDetail(ResourceDetail):
 
         if 'state' in data and data.get('send_email', None) and (session.state == 'accepted' or
                                                                  session.state == 'rejected'):
+
+            event = session.event
             # Email for speaker
             speakers = session.speakers
             for speaker in speakers:
                 frontend_url = get_settings()['frontend_url']
                 link = "{}/events/{}/sessions/{}" \
-                    .format(frontend_url, session.event_id, session.id)
+                    .format(frontend_url, event.identifier, session.id)
                 send_email_session_accept_reject(speaker.email, session, link)
                 send_notif_session_accept_reject(speaker, session.title, session.state, link, session.id)
 
@@ -141,7 +144,7 @@ class SessionDetail(ResourceDetail):
                 organizer_email = organizer.email
                 frontend_url = get_settings()['frontend_url']
                 link = "{}/events/{}/sessions/{}" \
-                    .format(frontend_url, session.event_id, session.id)
+                    .format(frontend_url, event.identifier, session.id)
                 send_email_session_accept_reject(organizer_email, session,
                                                  link)
                 send_notif_session_accept_reject(organizer, session.title,


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5581 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
The current session link format uses `event_id` instead of `identifier` as it should be used.

#### Changes proposed in this pull request:

- using `identifier` instead of `id` in the link


