### PR TITLE
make discount code case insensitive.

### DIFF
--- a/migrations/versions/f21e128ea3ef_create_case_insensitive_discount_codes.py
+++ b/migrations/versions/f21e128ea3ef_create_case_insensitive_discount_codes.py
@@ -1,0 +1,30 @@
+"""Create case insensitive discount codes
+
+Revision ID: f21e128ea3ef
+Revises: 7bb5891a9f2e
+Create Date: 2019-04-18 16:30:17.668956
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy_utils
+
+
+# revision identifiers, used by Alembic.
+revision = 'f21e128ea3ef'
+down_revision = '7bb5891a9f2e'
+
+
+def upgrade():
+    op.execute("UPDATE discount_codes SET code = concat(code, '_') where code not in (SELECT DISTINCT ON (upper(code)) code FROM discount_codes GROUP BY event_id);",
+               execution_options=None)
+    op.execute("alter table discount_codes alter column code type citext;",
+               execution_options=None)
+
+
+def downgrade():
+    op.execute("alter table discount_codes alter column code type text;",
+               execution_options=None)
+    op.execute("drop extension citext CASCADE;",
+               execution_options=None)


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5653 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
This makes case insensitive application of discount codes possible.

#### Changes proposed in this pull request:

- use ilike to perform case insensitive search over db for discount code.


