### PR TITLE
fix : remove redundant is_verified for super admin

### DIFF
--- a/tests/all/integration/auth_helper.py
+++ b/tests/all/integration/auth_helper.py
@@ -14,7 +14,7 @@ def create_user(email, password, is_verified=True):
 
 
 def create_super_admin(email, password):
-    user = create_user(email, password, is_verified=True)
+    user = create_user(email, password)
     user.is_super_admin = True
     user.is_admin = True
     save_to_db(user, "User updated")


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5675 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Apparently the super user being created is using the `default` value of `False` (i can confirm that the first super user being created is always unverified) and removing this parameter fixes it.

#### Changes proposed in this pull request:

- removing is_verified parameter from create_user.py


