### PR TITLE
Fix Migration which incorrectly modified confirmed sessions

### DIFF
--- a/migrations/versions/4defe72abed3_.py
+++ b/migrations/versions/4defe72abed3_.py
@@ -25,7 +25,7 @@ def upgrade():
     op.execute("""UPDATE events SET state = 'draft' WHERE state != 'published'""")
     op.execute("""UPDATE sessions SET state = LOWER(state)""")
     op.execute("""UPDATE sessions SET state = 'draft' WHERE state not in
-    ('accepted', 'pending', 'approved', 'rejected')""")
+    ('accepted', 'pending', 'confirmed', 'rejected')""")
     # ### end Alembic commands ###
 
 


### PR DESCRIPTION
Any of the sessions which had a confirmed state were modified to be drafts while transitioning from legacy.

Fixes: #5726