### PR TITLE
Calculate number of migration head correctly.

### DIFF
--- a/scripts/test_multiple_heads.sh
+++ b/scripts/test_multiple_heads.sh
@@ -1,4 +1,4 @@
-lines=`python3 manage.py db heads | wc | awk '{print $1}'`
+lines=`python3 manage.py db heads | grep -c "head" | wc | awk '{print $1}'`
 if [ $lines -ne 1 ]
 then
     echo "Error: Multiple Migration Heads"


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5650 

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [X] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Instead of counting the number of lines in the output, it should count the number of lines containing the word "head". 
