### PR TITLE
test: Add make_filename unit test for export_helpers.

### DIFF
--- a/tests/all/unit/api/helpers/test_export_helpers.py
+++ b/tests/all/unit/api/helpers/test_export_helpers.py
@@ -1,7 +1,7 @@
 import unittest
 
 from collections import OrderedDict
-from app.api.helpers.export_helpers import sorted_dict
+from app.api.helpers.export_helpers import sorted_dict, make_filename
 
 
 class TestExportHelperValidation(unittest.TestCase):
@@ -27,6 +27,64 @@ class TestExportHelperValidation(unittest.TestCase):
         self.assertEqual(expected_dictdata, response_dictdata)
         self.assertEqual(expected_ordereddict_data, response_ordereddict_data)
         self.assertEqual(expected_list_data, response_list_data)
+
+    def test_make_filename(self):
+        """Method to test speaker image filename for export"""
+
+        correct_data = 'correctfilename.png'
+        correct_response = 'Correctfilename.Png'
+        actual_response = make_filename(correct_data)
+        self.assertEqual(correct_response, actual_response)
+
+        data_with_lt = 'datawith<name.png'
+        response_with_lt = 'DatawithName.Png'
+        actual_response = make_filename(data_with_lt)
+        self.assertEqual(response_with_lt, actual_response)
+
+        data_with_gt = 'datawith>name.png'
+        response_with_gt = 'DatawithName.Png'
+        actual_response = make_filename(data_with_gt)
+        self.assertEqual(response_with_gt, actual_response)
+
+        data_with_colon = 'datawith:name.png'
+        response_with_colon = 'DatawithName.Png'
+        actual_response = make_filename(data_with_colon)
+        self.assertEqual(response_with_colon, actual_response)
+
+        data_with_doublequotes = 'datawith"quotes.png'
+        response_with_doublequotes = 'DatawithQuotes.Png'
+        actual_response = make_filename(data_with_doublequotes)
+        self.assertEqual(response_with_doublequotes, actual_response)
+
+        data_with_forwardslash = 'datawith/slash.png'
+        response_with_forwardslash = 'DatawithSlash.Png'
+        actual_response = make_filename(data_with_forwardslash)
+        self.assertEqual(response_with_forwardslash, actual_response)
+
+        data_with_backslash = 'datawith\\slash.png'
+        response_with_backslash = 'DatawithSlash.Png'
+        actual_response = make_filename(data_with_backslash)
+        self.assertEqual(response_with_backslash, actual_response)
+
+        data_with_verticalbar = 'datawith|bar.png'
+        response_with_verticalbar = 'DatawithBar.Png'
+        actual_response = make_filename(data_with_verticalbar)
+        self.assertEqual(response_with_verticalbar, actual_response)
+
+        data_with_questionmark = 'datawith?mark.png'
+        response_with_questionmark = 'DatawithMark.Png'
+        actual_response = make_filename(data_with_questionmark)
+        self.assertEqual(response_with_questionmark, actual_response)
+
+        data_with_star = 'datawith*operator.png'
+        response_with_star = 'DatawithOperator.Png'
+        actual_response = make_filename(data_with_star)
+        self.assertEqual(response_with_star, actual_response)
+
+        data_with_semicolon = 'datawith;semicolon.png'
+        response_with_semicolon = 'DatawithSemicolon.Png'
+        actual_response = make_filename(data_with_semicolon)
+        self.assertEqual(response_with_semicolon, actual_response)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Reference: #5320

<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
This PR adds unit test for `make_filename` function present in `export_helpers` file.

#### Changes proposed in this pull request:

- Add test

