### PR TITLE
fix: Strip whitespace from the end of email in authorisation.

### DIFF
--- a/app/api/helpers/jwt.py
+++ b/app/api/helpers/jwt.py
@@ -14,7 +14,7 @@ def jwt_authenticate(email, password):
     :param password:
     :return:
     """
-    user = User.query.filter_by(email=email, deleted_at=None).first()
+    user = User.query.filter_by(email=email.strip(), deleted_at=None).first()
     if user is None:
         return None
     auth_ok = user.facebook_login_hash == password or user.is_correct_password(password)


### PR DESCRIPTION
Fixes: https://github.com/fossasia/open-event-frontend/issues/2503

<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
This PR strips off white spaces (if any) in the user's login email so that the user can still login in case of any unintended whitespaces entered.

#### Changes proposed in this pull request:

- Use `.strip` function on email data entered.
