### PR TITLE
fix: Translation Downloads deletion fix(celery)

### DIFF
--- a/app/api/admin_translations.py
+++ b/app/api/admin_translations.py
@@ -18,7 +18,7 @@ def download_translations():
     shutil.move(zip_file_ext, temp_dir)
     path_to_zip = os.path.join(temp_dir, zip_file_ext)
     from .helpers.tasks import delete_translations
-    delete_translations.apply_async(path_to_zip, countdown=600)
+    delete_translations.apply_async(kwargs={'zip_file_path': path_to_zip}, countdown=600)
     return send_file(path_to_zip,  mimetype='application/zip',
                      as_attachment=True,
                      attachment_filename='translations.zip')


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5766

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
This resolves the `NoneType` assignment error arising because `celery.result.AsyncResult` returned by `apply_async` result is not being stored anywhere. 
 
#### Changes proposed in this pull request:

- Stored apply_async's return value in task
