### PR TITLE
fix: Make wrong current password error message more informative.

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -261,7 +261,7 @@ def change_password():
             send_notification_with_action(user, PASSWORD_CHANGE_NOTIF,
                                           app_name=get_settings()['app_name'])
         else:
-            return BadRequestError({'source': ''}, 'Wrong Password').respond()
+            return BadRequestError({'source': ''}, 'Wrong Password. Please enter correct current password.').respond()
 
     return jsonify({
         "id": user.id,


### PR DESCRIPTION
Fixes: #5768
Relevant Frontend PR: https://github.com/fossasia/open-event-frontend/pull/2547
Relevant Frontend Issue: https://github.com/fossasia/open-event-frontend/issues/2546
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
This makes the wrong current password error message more informative during password reset.

#### Changes proposed in this pull request:

- Modify the error message.


