### PR TITLE
fix: session slides saving error

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -175,7 +175,7 @@ class SessionDetail(ResourceDetail):
                                                                 session_id=session.id,
                                                                 event_id=session.event.id,
                                                                 speaker_id=speaker.id)
-            save_to_db(session_speaker_link, "Session Speaker Link Saved")
+                save_to_db(session_speaker_link, "Session Speaker Link Saved")
 
     decorators = (api.has_permission('is_speaker_for_session', methods="PATCH,DELETE"),)
     schema = SessionSchema


### PR DESCRIPTION
Fixes: #5771

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
While adding,removing or editing slides field in a session, an error comes up. This makes it possible to add,remove or edit slides in a session.

#### Changes proposed in this pull request:

- Move the `save_to_db` in its relevant code section.

