### PR TITLE
test: Add unit test for handle_unserializable_data present in export_helpers

### DIFF
--- a/tests/all/unit/api/helpers/test_export_helpers.py
+++ b/tests/all/unit/api/helpers/test_export_helpers.py
@@ -1,7 +1,8 @@
 import unittest
 
 from collections import OrderedDict
-from app.api.helpers.export_helpers import sorted_dict, make_filename
+from app.api.helpers.export_helpers import sorted_dict, make_filename, handle_unserializable_data
+from datetime import datetime
 
 
 class TestExportHelperValidation(unittest.TestCase):
@@ -85,6 +86,20 @@ class TestExportHelperValidation(unittest.TestCase):
         response_with_semicolon = 'DatawithSemicolon.Png'
         actual_response = make_filename(data_with_semicolon)
         self.assertEqual(response_with_semicolon, actual_response)
+
+    def test_handle_unserializable_data(self):
+        """
+        Method to test Handling of objects which cannot be serialized by json.dumps()
+        """
+        query_correct = datetime(2006, 11, 21, 16, 30, 12, 841100)
+        expected_response = '2006-11-21 16:30:12.841100'
+        actual_response = handle_unserializable_data(query_correct)
+        self.assertEqual(expected_response, actual_response)
+
+        query_incorrect = ['sample', 'data', 'incorrect']
+        expected_response = None
+        actual_response = handle_unserializable_data(query_incorrect)
+        self.assertEqual(expected_response, actual_response)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Reference: #5320

<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
This adds a unit test for `handle_unserializable_data` present in `export_helpers`.

#### Changes proposed in this pull request:

- Write unit test.