### PR TITLE
fix: Add check for ticket and CFS ends-at

### DIFF
--- a/app/api/schema/speakers_calls.py
+++ b/app/api/schema/speakers_calls.py
@@ -35,6 +35,14 @@ class SpeakersCallSchema(SoftDeletionSchema):
         if data['starts_at'] >= data['ends_at']:
             raise UnprocessableEntity({'pointer': '/data/attributes/ends-at'}, "ends-at should be after starts-at")
 
+        if data['starts_at'] > speakers_calls.event.ends_at:
+            raise UnprocessableEntity({'pointer': '/data/attributes/starts-at'},
+                                      "speakers-call starts-at should be before event ends-at")
+
+        if data['ends_at'] > speakers_calls.event.ends_at:
+            raise UnprocessableEntity({'pointer': '/data/attributes/ends-at'},
+                                      "speakers-call ends-at should be before event ends-at")
+
     id = fields.Str(dump_only=True)
     announcement = fields.Str(required=True)
     starts_at = fields.DateTime(required=True)

--- a/app/api/schema/speakers_calls.py
+++ b/app/api/schema/speakers_calls.py
@@ -32,19 +32,19 @@ class SpeakersCallSchema(SoftDeletionSchema):
             if 'ends_at' not in data:
                 data['ends_at'] = speakers_calls.ends_at
 
-            if 'event_ends_at' not in data:
-                data['event_ends_at'] = speakers_calls.event.ends_at
+            if 'event_starts_at' not in data:
+                data['event_starts_at'] = speakers_calls.event.starts_at
 
         if data['starts_at'] >= data['ends_at']:
             raise UnprocessableEntity({'pointer': '/data/attributes/ends-at'}, "ends-at should be after starts-at")
 
-        if data['starts_at'] > data['event_ends_at']:
+        if 'event_starts_at' in data and data['starts_at'] > data['event_starts_at']:
             raise UnprocessableEntity({'pointer': '/data/attributes/starts-at'},
-                                      "speakers-call starts-at should be before event ends-at")
+                                      "speakers-call starts-at should be before event starts-at")
 
-        if data['ends_at'] > data['event_ends_at']:
+        if 'event_starts_at' in data and data['ends_at'] > data['event_starts_at']:
             raise UnprocessableEntity({'pointer': '/data/attributes/ends-at'},
-                                      "speakers-call ends-at should be before event ends-at")
+                                      "speakers-call ends-at should be before event starts-at")
 
     id = fields.Str(dump_only=True)
     announcement = fields.Str(required=True)

--- a/app/api/schema/speakers_calls.py
+++ b/app/api/schema/speakers_calls.py
@@ -32,14 +32,17 @@ class SpeakersCallSchema(SoftDeletionSchema):
             if 'ends_at' not in data:
                 data['ends_at'] = speakers_calls.ends_at
 
+            if 'event_ends_at' not in data:
+                data['event_ends_at'] = speakers_calls.event.ends_at
+
         if data['starts_at'] >= data['ends_at']:
             raise UnprocessableEntity({'pointer': '/data/attributes/ends-at'}, "ends-at should be after starts-at")
 
-        if data['starts_at'] > speakers_calls.event.ends_at:
+        if data['starts_at'] > data['event_ends_at']:
             raise UnprocessableEntity({'pointer': '/data/attributes/starts-at'},
                                       "speakers-call starts-at should be before event ends-at")
 
-        if data['ends_at'] > speakers_calls.event.ends_at:
+        if data['ends_at'] > data['event_ends_at']:
             raise UnprocessableEntity({'pointer': '/data/attributes/ends-at'},
                                       "speakers-call ends-at should be before event ends-at")
 

--- a/app/api/schema/tickets.py
+++ b/app/api/schema/tickets.py
@@ -29,7 +29,7 @@ class TicketSchemaPublic(SoftDeletionSchema):
 
             if 'sales_ends_at' not in data:
                 data['sales_ends_at'] = ticket.sales_ends_at
-   
+
             if 'event_ends_at' not in data:
                 data['event_ends_at'] = ticket.event.ends_at
 

--- a/app/api/schema/tickets.py
+++ b/app/api/schema/tickets.py
@@ -29,7 +29,7 @@ class TicketSchemaPublic(SoftDeletionSchema):
 
             if 'sales_ends_at' not in data:
                 data['sales_ends_at'] = ticket.sales_ends_at
-         
+   
             if 'event_ends_at' not in data:
                 data['event_ends_at'] = ticket.event.ends_at
 
@@ -37,11 +37,11 @@ class TicketSchemaPublic(SoftDeletionSchema):
             raise UnprocessableEntity({'pointer': '/data/attributes/sales-ends-at'},
                                       "sales-ends-at should be after sales-starts-at")
 
-        if data['sales_starts_at'] > data['event_ends_at']:
+        if 'event_ends_at' in data and data['sales_starts_at'] > data['event_ends_at']:
             raise UnprocessableEntity({'pointer': '/data/attributes/sales-starts-at'},
                                       "ticket sales-starts-at should be before event ends-at")
 
-        if data['sales_ends_at'] > data['event_ends_at']:
+        if 'event_ends_at' in data and data['sales_ends_at'] > data['event_ends_at']:
             raise UnprocessableEntity({'pointer': '/data/attributes/sales-ends-at'},
                                       "ticket sales-ends-at should be before event ends-at")
 

--- a/app/api/schema/tickets.py
+++ b/app/api/schema/tickets.py
@@ -34,6 +34,14 @@ class TicketSchemaPublic(SoftDeletionSchema):
             raise UnprocessableEntity({'pointer': '/data/attributes/sales-ends-at'},
                                       "sales-ends-at should be after sales-starts-at")
 
+        if data['sales_starts_at'] > ticket.event.ends_at:
+            raise UnprocessableEntity({'pointer': '/data/attributes/sales-starts-at'},
+                                      "ticket sales-starts-at should be before event ends-at")
+
+        if data['sales_ends_at'] > ticket.event.ends_at:
+            raise UnprocessableEntity({'pointer': '/data/attributes/sales-ends-at'},
+                                      "ticket sales-ends-at should be before event ends-at")
+
     @validates_schema
     def validate_quantity(self, data):
         if 'max_order' in data and 'min_order' in data:

--- a/app/api/schema/tickets.py
+++ b/app/api/schema/tickets.py
@@ -29,16 +29,19 @@ class TicketSchemaPublic(SoftDeletionSchema):
 
             if 'sales_ends_at' not in data:
                 data['sales_ends_at'] = ticket.sales_ends_at
+         
+            if 'event_ends_at' not in data:
+                data['event_ends_at'] = ticket.event.ends_at
 
         if data['sales_starts_at'] >= data['sales_ends_at']:
             raise UnprocessableEntity({'pointer': '/data/attributes/sales-ends-at'},
                                       "sales-ends-at should be after sales-starts-at")
 
-        if data['sales_starts_at'] > ticket.event.ends_at:
+        if data['sales_starts_at'] > data['event_ends_at']:
             raise UnprocessableEntity({'pointer': '/data/attributes/sales-starts-at'},
                                       "ticket sales-starts-at should be before event ends-at")
 
-        if data['sales_ends_at'] > ticket.event.ends_at:
+        if data['sales_ends_at'] > data['event_ends_at']:
             raise UnprocessableEntity({'pointer': '/data/attributes/sales-ends-at'},
                                       "ticket sales-ends-at should be before event ends-at")
 

--- a/tests/all/integration/api/validation/test_speakers_call.py
+++ b/tests/all/integration/api/validation/test_speakers_call.py
@@ -27,7 +27,8 @@ class TestSpeakersCallValidation(OpenEventTestCase):
         }
         data = {
             'starts_at': datetime(2003, 8, 4, 12, 30, 45).replace(tzinfo=timezone('UTC')),
-            'ends_at': datetime(2003, 9, 4, 12, 30, 45).replace(tzinfo=timezone('UTC'))
+            'ends_at': datetime(2003, 9, 4, 12, 30, 45).replace(tzinfo=timezone('UTC')),
+            'event_ends_at': datetime(2003, 9, 10, 12, 30, 45).replace(tzinfo=timezone('UTC'))
         }
         SpeakersCallSchema.validate_date(schema, data, original_data)
 
@@ -42,7 +43,42 @@ class TestSpeakersCallValidation(OpenEventTestCase):
         }
         data = {
             'starts_at': datetime(2003, 9, 4, 12, 30, 45).replace(tzinfo=timezone('UTC')),
-            'ends_at': datetime(2003, 8, 4, 12, 30, 45).replace(tzinfo=timezone('UTC'))
+            'ends_at': datetime(2003, 8, 4, 12, 30, 45).replace(tzinfo=timezone('UTC')),
+            'event_ends_at': datetime(2003, 9, 10, 12, 30, 45).replace(tzinfo=timezone('UTC'))
+        }
+        with self.assertRaises(UnprocessableEntity):
+            SpeakersCallSchema.validate_date(schema, data, original_data)
+
+    def test_date_start_gt_event_end(self):
+        """
+        Speakers Call Validate Date - Tests if exception is raised when speakers_call starts_at is after event ends_at
+        :return:
+        """
+        schema = SpeakersCallSchema()
+        original_data = {
+            'data': {}
+        }
+        data = {
+            'starts_at': datetime(2003, 9, 4, 12, 30, 45).replace(tzinfo=timezone('UTC')),
+            'ends_at': datetime(2003, 9, 10, 12, 30, 45).replace(tzinfo=timezone('UTC')),
+            'event_ends_at': datetime(2003, 9, 2, 12, 30, 45).replace(tzinfo=timezone('UTC'))
+        }
+        with self.assertRaises(UnprocessableEntity):
+            SpeakersCallSchema.validate_date(schema, data, original_data)
+
+    def test_date_end_gt_event_end(self):
+        """
+        Speakers Call Validate Date - Tests if exception is raised when speakers_call ends_at is after event ends_at
+        :return:
+        """
+        schema = SpeakersCallSchema()
+        original_data = {
+            'data': {}
+        }
+        data = {
+            'starts_at': datetime(2003, 9, 2, 12, 30, 45).replace(tzinfo=timezone('UTC')),
+            'ends_at': datetime(2003, 9, 10, 12, 30, 45).replace(tzinfo=timezone('UTC')),
+            'event_ends_at': datetime(2003, 9, 5, 12, 30, 45).replace(tzinfo=timezone('UTC'))
         }
         with self.assertRaises(UnprocessableEntity):
             SpeakersCallSchema.validate_date(schema, data, original_data)

--- a/tests/all/integration/api/validation/test_speakers_call.py
+++ b/tests/all/integration/api/validation/test_speakers_call.py
@@ -28,7 +28,7 @@ class TestSpeakersCallValidation(OpenEventTestCase):
         data = {
             'starts_at': datetime(2003, 8, 4, 12, 30, 45).replace(tzinfo=timezone('UTC')),
             'ends_at': datetime(2003, 9, 4, 12, 30, 45).replace(tzinfo=timezone('UTC')),
-            'event_ends_at': datetime(2003, 9, 10, 12, 30, 45).replace(tzinfo=timezone('UTC'))
+            'event_starts_at': datetime(2003, 9, 10, 12, 30, 45).replace(tzinfo=timezone('UTC'))
         }
         SpeakersCallSchema.validate_date(schema, data, original_data)
 
@@ -44,14 +44,14 @@ class TestSpeakersCallValidation(OpenEventTestCase):
         data = {
             'starts_at': datetime(2003, 9, 4, 12, 30, 45).replace(tzinfo=timezone('UTC')),
             'ends_at': datetime(2003, 8, 4, 12, 30, 45).replace(tzinfo=timezone('UTC')),
-            'event_ends_at': datetime(2003, 9, 10, 12, 30, 45).replace(tzinfo=timezone('UTC'))
+            'event_starts_at': datetime(2003, 9, 10, 12, 30, 45).replace(tzinfo=timezone('UTC'))
         }
         with self.assertRaises(UnprocessableEntity):
             SpeakersCallSchema.validate_date(schema, data, original_data)
 
     def test_date_start_gt_event_end(self):
         """
-        Speakers Call Validate Date - Tests if exception is raised when speakers_call starts_at is after event ends_at
+        Speakers Call Validate Date - Tests if exception is raised when speakers_call starts_at is after event starts_at
         :return:
         """
         schema = SpeakersCallSchema()
@@ -61,14 +61,14 @@ class TestSpeakersCallValidation(OpenEventTestCase):
         data = {
             'starts_at': datetime(2003, 9, 4, 12, 30, 45).replace(tzinfo=timezone('UTC')),
             'ends_at': datetime(2003, 9, 10, 12, 30, 45).replace(tzinfo=timezone('UTC')),
-            'event_ends_at': datetime(2003, 9, 2, 12, 30, 45).replace(tzinfo=timezone('UTC'))
+            'event_starts_at': datetime(2003, 9, 2, 12, 30, 45).replace(tzinfo=timezone('UTC'))
         }
         with self.assertRaises(UnprocessableEntity):
             SpeakersCallSchema.validate_date(schema, data, original_data)
 
     def test_date_end_gt_event_end(self):
         """
-        Speakers Call Validate Date - Tests if exception is raised when speakers_call ends_at is after event ends_at
+        Speakers Call Validate Date - Tests if exception is raised when speakers_call ends_at is after event starts_at
         :return:
         """
         schema = SpeakersCallSchema()
@@ -78,7 +78,7 @@ class TestSpeakersCallValidation(OpenEventTestCase):
         data = {
             'starts_at': datetime(2003, 9, 2, 12, 30, 45).replace(tzinfo=timezone('UTC')),
             'ends_at': datetime(2003, 9, 10, 12, 30, 45).replace(tzinfo=timezone('UTC')),
-            'event_ends_at': datetime(2003, 9, 5, 12, 30, 45).replace(tzinfo=timezone('UTC'))
+            'event_starts_at': datetime(2003, 9, 5, 12, 30, 45).replace(tzinfo=timezone('UTC'))
         }
         with self.assertRaises(UnprocessableEntity):
             SpeakersCallSchema.validate_date(schema, data, original_data)

--- a/tests/all/integration/api/validation/test_tickets.py
+++ b/tests/all/integration/api/validation/test_tickets.py
@@ -28,7 +28,7 @@ class TestTicketValidation(OpenEventTestCase):
         data = {
             'sales_starts_at': datetime(2003, 8, 4, 12, 30, 45).replace(tzinfo=timezone('UTC')),
             'sales_ends_at': datetime(2003, 9, 4, 12, 30, 45).replace(tzinfo=timezone('UTC')),
-            'event_ends_at': datetime(2003, 8, 10, 12, 30, 45).replace(tzinfo=timezone('UTC'))
+            'event_ends_at': datetime(2003, 9, 10, 12, 30, 45).replace(tzinfo=timezone('UTC'))
         }
         TicketSchema.validate_date(schema, data, original_data)
 

--- a/tests/all/integration/api/validation/test_tickets.py
+++ b/tests/all/integration/api/validation/test_tickets.py
@@ -27,7 +27,8 @@ class TestTicketValidation(OpenEventTestCase):
         }
         data = {
             'sales_starts_at': datetime(2003, 8, 4, 12, 30, 45).replace(tzinfo=timezone('UTC')),
-            'sales_ends_at': datetime(2003, 9, 4, 12, 30, 45).replace(tzinfo=timezone('UTC'))
+            'sales_ends_at': datetime(2003, 9, 4, 12, 30, 45).replace(tzinfo=timezone('UTC')),
+            'event_ends_at': datetime(2003, 8, 10, 12, 30, 45).replace(tzinfo=timezone('UTC'))
         }
         TicketSchema.validate_date(schema, data, original_data)
 
@@ -42,7 +43,42 @@ class TestTicketValidation(OpenEventTestCase):
         }
         data = {
             'sales_starts_at': datetime(2003, 9, 4, 12, 30, 45).replace(tzinfo=timezone('UTC')),
-            'sales_ends_at': datetime(2003, 8, 4, 12, 30, 45).replace(tzinfo=timezone('UTC'))
+            'sales_ends_at': datetime(2003, 8, 4, 12, 30, 45).replace(tzinfo=timezone('UTC')),
+            'event_ends_at': datetime(2003, 8, 10, 12, 30, 45).replace(tzinfo=timezone('UTC'))
+        }
+        with self.assertRaises(UnprocessableEntity):
+            TicketSchema.validate_date(schema, data, original_data)
+
+    def test_date_start_gt_event_end(self):
+        """
+        Tickets Validate Date - Tests if exception is raised when sales_starts_at is after event ends_at
+        :return:
+        """
+        schema = TicketSchema()
+        original_data = {
+            'data': {}
+        }
+        data = {
+            'sales_starts_at': datetime(2003, 8, 4, 12, 30, 45).replace(tzinfo=timezone('UTC')),
+            'sales_ends_at': datetime(2003, 9, 4, 12, 30, 45).replace(tzinfo=timezone('UTC')),
+            'event_ends_at': datetime(2003, 8, 2, 12, 30, 45).replace(tzinfo=timezone('UTC'))
+        }
+        with self.assertRaises(UnprocessableEntity):
+            TicketSchema.validate_date(schema, data, original_data)
+
+    def test_date_end_gt_event_end(self):
+        """
+        Tickets Validate Date - Tests if exception is raised when sales_ends_at is after event ends_at
+        :return:
+        """
+        schema = TicketSchema()
+        original_data = {
+            'data': {}
+        }
+        data = {
+            'sales_starts_at': datetime(2003, 8, 1, 12, 30, 45).replace(tzinfo=timezone('UTC')),
+            'sales_ends_at': datetime(2003, 8, 10, 12, 30, 45).replace(tzinfo=timezone('UTC')),
+            'event_ends_at': datetime(2003, 8, 2, 12, 30, 45).replace(tzinfo=timezone('UTC'))
         }
         with self.assertRaises(UnprocessableEntity):
             TicketSchema.validate_date(schema, data, original_data)


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #
Related issue https://github.com/fossasia/open-event-frontend/issues/2653

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Currently, the CFS end date and ticket end date can be more than the event end date. Proper error must be raised on such cases

#### Changes proposed in this pull request:
- Add check for these conditions