### PR TITLE
fix: Create checks for event identifiers being passed as ids

### DIFF
--- a/app/api/events.py
+++ b/app/api/events.py
@@ -444,7 +444,7 @@ class EventDetail(ResourceDetail):
         :param view_kwargs:
         :return:
         """
-        kwargs = get_id(kwargs)
+        get_id(view_kwargs)
 
         if view_kwargs.get('order_identifier') is not None:
             order = safe_query(self, Order, 'identifier', view_kwargs['order_identifier'], 'order_identifier')

--- a/app/api/events.py
+++ b/app/api/events.py
@@ -426,7 +426,13 @@ class EventDetail(ResourceDetail):
         :param kwargs:
         :return:
         """
+        if 'id' in kwargs:
+            # condition to check if id is actually numerical identifier
+            if len(str(kwargs['id'])) >= 5:
+                new_kwarg = {'identifier': str(kwargs['id'])}
+                kwargs = new_kwarg
         kwargs = get_id(kwargs)
+
         if 'Authorization' in request.headers and has_access('is_coorganizer', event_id=kwargs['id']):
             self.schema = EventSchema
         else:
@@ -438,11 +444,6 @@ class EventDetail(ResourceDetail):
         :param view_kwargs:
         :return:
         """
-        if 'id' in kwargs:
-            # condition to check if id is actually numerical identifier
-            if len(str(kwargs['id'])) >= 5:
-                new_kwarg = {'identifier': str(kwargs['id'])}
-                kwargs = new_kwarg
         kwargs = get_id(kwargs)
 
         if view_kwargs.get('order_identifier') is not None:

--- a/app/api/events.py
+++ b/app/api/events.py
@@ -438,7 +438,12 @@ class EventDetail(ResourceDetail):
         :param view_kwargs:
         :return:
         """
-        get_id(view_kwargs)
+        if 'id' in kwargs:
+            # condition to check if id is actually numerical identifier
+            if len(str(kwargs['id'])) >= 5:
+                new_kwarg = {'identifier': str(kwargs['id'])}
+                kwargs = new_kwarg
+        kwargs = get_id(kwargs)
 
         if view_kwargs.get('order_identifier') is not None:
             order = safe_query(self, Order, 'identifier', view_kwargs['order_identifier'], 'order_identifier')


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5811

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
In the current situation, if an event identifier is completely integer, it is being passed as `{id : <identifier integer>` instead of normal `{identifier : <identifier string>}` in the kwargs.

So, in case an event has a numeric identifier, let's modify the incoming kwarg request and modify it into the usual format.

#### Changes proposed in this pull request:

- Checking if the incoming kwargs are usual
- Reformatting them in case of integers


