### PR TITLE
fix: Admin translations security

### DIFF
--- a/app/api/admin_translations.py
+++ b/app/api/admin_translations.py
@@ -3,12 +3,14 @@ import shutil
 import uuid
 import tempfile
 import os
+from app.api.helpers.permissions import is_admin
 
 admin_blueprint = Blueprint('admin_blueprint', __name__, url_prefix='/v1/admin/content/translations/all')
 temp_dir = tempfile.gettempdir()
 translations_dir = 'app/translations'
 
 @admin_blueprint.route('/', methods=['GET'])
+@is_admin
 def download_translations():
     """Admin Translations Downloads"""
     uuid_literal = uuid.uuid4()


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5817 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Fixes the security issue for admin translations. Only allows admins to access it.

#### Changes proposed in this pull request:

- Added `is_admin` decorator

