### PR TITLE
fix: notify when old and new passwords are same while changing password

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -251,6 +251,9 @@ def change_password():
         return NotFoundError({'source': ''}, 'User Not Found').respond()
     else:
         if user.is_correct_password(old_password):
+            if user.is_correct_password(new_password):
+                return BadRequestError({'source': ''},
+                                       'Old and New passwords must be different').respond()
             if len(new_password) < 8:
                 return BadRequestError({'source': ''},
                                        'Password should have minimum 8 characters').respond()


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5794

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Currently, there is no check if user is entering same old and new password while changing passwords.

#### Changes proposed in this pull request:
 - Adds error message `Old and New passwords must be different` when user enters same old and new password while changing password.


