### PR TITLE
fix: Allow a non-admin speaker to handle his speaker details

### DIFF
--- a/app/api/helpers/permission_manager.py
+++ b/app/api/helpers/permission_manager.py
@@ -170,6 +170,9 @@ def is_speaker_itself_or_admin(view, view_args, view_kwargs, *args, **kwargs):
     """
     user = current_identity
 
+    if user.is_admin or user.is_super_admin:
+        return view(*view_args, **view_kwargs)
+
     if user.is_organizer(kwargs['event_id']) or user.is_coorganizer(kwargs['event_id']):
         return view(*view_args, **view_kwargs)
 

--- a/app/api/helpers/permission_manager.py
+++ b/app/api/helpers/permission_manager.py
@@ -163,18 +163,12 @@ def is_speaker_for_session(view, view_args, view_kwargs, *args, **kwargs):
 
 
 @jwt_required
-def is_speaker_via_cfs(view, view_args, view_kwargs, *args, **kwargs):
+def is_speaker_itself_or_admin(view, view_args, view_kwargs, *args, **kwargs):
     """
     Allows admin and super admin access to any resource irrespective of id.
     Otherwise the user can only access his/her resource.
     """
     user = current_identity
-
-    if user.is_admin or user.is_super_admin or ('user_id' in kwargs and user.id == kwargs['user_id']):
-        return view(*view_args, **view_kwargs)
-
-    if user.is_staff:
-        return view(*view_args, **view_kwargs)
 
     if user.is_organizer(kwargs['event_id']) or user.is_coorganizer(kwargs['event_id']):
         return view(*view_args, **view_kwargs)
@@ -331,7 +325,7 @@ permissions = {
     'is_coorganizer_endpoint_related_to_event': is_coorganizer_endpoint_related_to_event,
     'is_registrar_or_user_itself': is_registrar_or_user_itself,
     'is_coorganizer_but_not_admin': is_coorganizer_but_not_admin,
-    'is_speaker_via_cfs': is_speaker_via_cfs
+    'is_speaker_itself_or_admin': is_speaker_itself_or_admin
 }
 
 

--- a/app/api/helpers/permission_manager.py
+++ b/app/api/helpers/permission_manager.py
@@ -8,6 +8,7 @@ from app.api.helpers.permissions import jwt_required
 from app.models.session import Session
 from app.models.event import Event
 from app.models.order import Order
+from app.models.speaker import Speaker
 from app.api.helpers.jwt import get_identity
 
 
@@ -162,6 +163,31 @@ def is_speaker_for_session(view, view_args, view_kwargs, *args, **kwargs):
 
 
 @jwt_required
+def is_speaker_via_cfs(view, view_args, view_kwargs, *args, **kwargs):
+    """
+    Allows admin and super admin access to any resource irrespective of id.
+    Otherwise the user can only access his/her resource.
+    """
+    user = current_identity
+
+    if user.is_admin or user.is_super_admin or ('user_id' in kwargs and user.id == kwargs['user_id']):
+        return view(*view_args, **view_kwargs)
+
+    if user.is_staff:
+        return view(*view_args, **view_kwargs)
+
+    if user.is_organizer(kwargs['event_id']) or user.is_coorganizer(kwargs['event_id']):
+        return view(*view_args, **view_kwargs)
+
+    if ('model' in kwargs) and (kwargs['model'] == Speaker):
+        query_user = Speaker.query.filter_by(email=user._email).first()
+        if query_user:
+            return view(*view_args, **view_kwargs)
+
+    return ForbiddenError({'source': ''}, 'Detail ownership is required, access denied.').respond()
+
+
+@jwt_required
 def is_session_self_submitted(view, view_args, view_kwargs, *args, **kwargs):
     """
     Allows admin and super admin access to any resource irrespective of id.
@@ -304,7 +330,8 @@ permissions = {
     'is_user_itself': is_user_itself,
     'is_coorganizer_endpoint_related_to_event': is_coorganizer_endpoint_related_to_event,
     'is_registrar_or_user_itself': is_registrar_or_user_itself,
-    'is_coorganizer_but_not_admin': is_coorganizer_but_not_admin
+    'is_coorganizer_but_not_admin': is_coorganizer_but_not_admin,
+    'is_speaker_via_cfs': is_speaker_via_cfs
 }
 
 

--- a/app/api/speakers.py
+++ b/app/api/speakers.py
@@ -145,7 +145,7 @@ class SpeakerDetail(ResourceDetail):
                                                                 speaker_id=speaker.id)
                     save_to_db(session_speaker_link, "Session Speaker Link Saved")
 
-    decorators = (api.has_permission('is_coorganizer_or_user_itself', methods="PATCH,DELETE", fetch="event_id",
+    decorators = (api.has_permission('is_speaker_via_cfs', methods="PATCH,DELETE", fetch="event_id",
                                      fetch_as="event_id", model=Speaker),)
     schema = SpeakerSchema
     data_layer = {'session': db.session,

--- a/app/api/speakers.py
+++ b/app/api/speakers.py
@@ -145,7 +145,9 @@ class SpeakerDetail(ResourceDetail):
                                                                 speaker_id=speaker.id)
                     save_to_db(session_speaker_link, "Session Speaker Link Saved")
 
-    decorators = (api.has_permission('is_speaker_via_cfs', methods="PATCH,DELETE", fetch="event_id",
+    decorators = (api.has_permission('is_speaker_itself_or_admin', methods="PATCH,DELETE", fetch="event_id",
+                                     fetch_as="event_id", model=Speaker),
+                  api.has_permission('is_coorganizer_or_user_itself', methods="PATCH,DELETE", fetch="event_id",
                                      fetch_as="event_id", model=Speaker),)
     schema = SpeakerSchema
     data_layer = {'session': db.session,


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5825 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Makes sure that the speaker can access his own speaker details.

#### Changes proposed in this pull request:

- add a new condition that checks if speaker detail exists for current speaker


