### PR TITLE
fix: Fixes the incomplete path of ticket downloads

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -8,6 +8,7 @@ from flask import request, jsonify, make_response, Blueprint, send_file, url_for
 from flask_jwt import current_identity as current_user, jwt_required
 from sqlalchemy.orm.exc import NoResultFound
 from app.api.helpers.order import create_pdf_tickets_for_holder
+from app.api.helpers.storage import generate_hash
 
 from app import get_settings
 from app.api.helpers.db import save_to_db, get_count
@@ -290,8 +291,8 @@ def ticket_attendee_authorized(order_identifier):
         except NoResultFound:
             return NotFoundError({'source': ''}, 'This ticket is not associated with any order').respond()
         if current_user.id == user_id:
-            file_path = os.path.join('/generated/tickets/{}'.format(UPLOAD_PATHS['pdf']['ticket_attendee']
-                                         .format(identifier=order_identifier)), order_identifier + '.pdf')
+            key = UPLOAD_PATHS['pdf']['ticket_attendee'].format(identifier=order_identifier)
+            file_path = '../generated/tickets/{}/{}/'.format(key, generate_hash(key)) + order_identifier + '.pdf'
             try:
                 response = make_response(send_file(file_path))
                 response.headers['Content-Disposition'] = 'attachment; filename=ticket-%s.zip' % order_identifier

--- a/app/api/helpers/files.py
+++ b/app/api/helpers/files.py
@@ -257,7 +257,7 @@ def make_frontend_url(path, parameters=None):
     ))
 
 
-def create_save_pdf(pdf_data, key, dir_path='/static/uploads/pdf/temp/', identifier=get_file_name(), upload_dir='static/media'):
+def create_save_pdf(pdf_data, key, dir_path='/static/uploads/pdf/temp/', identifier=get_file_name(), upload_dir='static/media/'):
     """
     Create and Saves PDFs from html
     :param pdf_data:

--- a/app/api/helpers/storage.py
+++ b/app/api/helpers/storage.py
@@ -130,7 +130,7 @@ class UploadedMemory(object):
 # MAIN
 #########
 
-def upload(uploaded_file, key, upload_dir='static/media', **kwargs):
+def upload(uploaded_file, key, upload_dir='static/media/', **kwargs):
     """
     Upload handler
     """
@@ -155,7 +155,7 @@ def upload(uploaded_file, key, upload_dir='static/media', **kwargs):
         return upload_local(uploaded_file, key, upload_dir, **kwargs)
 
 
-def upload_local(uploaded_file, key, upload_dir='static/media', **kwargs):
+def upload_local(uploaded_file, key, upload_dir='static/media/', **kwargs):
     """
     Uploads file locally. Base dir - static/media/
     """


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5829 #5831

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
This fixes the incomplete path of the ticket and default uploads path for other uploads.

#### Changes proposed in this pull request:

- Added hash of the key generated in the path.

- Default `upload_dir` parameter in `upload_local` misses leading slash