### PR TITLE
fix: allow patch request in the case when the session is being created

### DIFF
--- a/app/api/helpers/permission_manager.py
+++ b/app/api/helpers/permission_manager.py
@@ -154,12 +154,11 @@ def is_speaker_for_session(view, view_args, view_kwargs, *args, **kwargs):
         return view(*view_args, **view_kwargs)
 
     if session.speakers:
-        # If the session is being edited
         for speaker in session.speakers:
             if speaker.user_id == user.id:
                 return view(*view_args, **view_kwargs)
-    else:
-        # If the session is being created
+
+    if session.creator_id == user.id:
         return view(*view_args, **view_kwargs)
 
     return ForbiddenError({'source': ''}, 'Access denied.').respond()

--- a/app/api/helpers/permission_manager.py
+++ b/app/api/helpers/permission_manager.py
@@ -154,9 +154,13 @@ def is_speaker_for_session(view, view_args, view_kwargs, *args, **kwargs):
         return view(*view_args, **view_kwargs)
 
     if session.speakers:
+        # If the session is being edited
         for speaker in session.speakers:
             if speaker.user_id == user.id:
                 return view(*view_args, **view_kwargs)
+    else:
+        # If the session is being created
+        return view(*view_args, **view_kwargs)
 
     return ForbiddenError({'source': ''}, 'Access denied.').respond()
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5836

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Allows the user to patch a session in case he is not admin upon session creation. Once the session has been created, no other non-admin user will be able to access the resource as requested.

#### Changes proposed in this pull request:

- Allow patch in case the session has no speakers
