### PR TITLE
fix: Number of sessions(based on state) shown correctly

### DIFF
--- a/app/api/schema/event_statistics.py
+++ b/app/api/schema/event_statistics.py
@@ -34,32 +34,32 @@ class EventStatisticsGeneralSchema(Schema):
     sponsors = fields.Method("sponsors_count")
 
     def sessions_draft_count(self, obj):
-        return Session.query.filter_by(event_id=obj.id, state='draft').count()
+        return Session.query.filter_by(event_id=obj.id, state='draft', deleted_at=None).count()
 
     def sessions_submitted_count(self, obj):
-        return Session.query.filter_by(event_id=obj.id, state='submitted').count()
+        return Session.query.filter_by(event_id=obj.id, deleted_at=None).count()
 
     def sessions_accepted_count(self, obj):
-        return Session.query.filter_by(event_id=obj.id, state='accepted').count()
+        return Session.query.filter_by(event_id=obj.id, state='accepted', deleted_at=None).count()
 
     def sessions_confirmed_count(self, obj):
-        return Session.query.filter_by(event_id=obj.id, state='confirmed').count()
+        return Session.query.filter_by(event_id=obj.id, state='confirmed', deleted_at=None).count()
 
     def sessions_pending_count(self, obj):
-        return Session.query.filter_by(event_id=obj.id, state='pending').count()
+        return Session.query.filter_by(event_id=obj.id, state='pending', deleted_at=None).count()
 
     def sessions_rejected_count(self, obj):
-        return Session.query.filter_by(event_id=obj.id, state='rejected').count()
+        return Session.query.filter_by(event_id=obj.id, state='rejected', deleted_at=None).count()
 
     def speakers_count_type(self, obj, state='pending'):
-        return SessionsSpeakersLink.query.filter_by(event_id=obj.id, session_state=state).count()
+        return SessionsSpeakersLink.query.filter_by(event_id=obj.id, session_state=state, deleted_at=None).count()
 
     def speakers_count(self, obj):
         accepted = self.speakers_count_type(obj=obj, state='accepted')
         confirmed = self.speakers_count_type(obj=obj, state='confirmed')
         pending = self.speakers_count_type(obj=obj, state='pending')
         rejected = self.speakers_count_type(obj=obj, state='rejected')
-        total = Speaker.query.filter_by(event_id=obj.id).count()
+        total = Speaker.query.filter_by(event_id=obj.id, deleted_at=None).count()
         serial_data = {
                        'accepted': accepted,
                        'confirmed': confirmed,
@@ -70,7 +70,7 @@ class EventStatisticsGeneralSchema(Schema):
         return serial_data
 
     def sessions_count(self, obj):
-        return Session.query.filter_by(event_id=obj.id).count()
+        return Session.query.filter_by(event_id=obj.id, deleted_at=None).count()
 
     def sponsors_count(self, obj):
-        return Sponsor.query.filter_by(event_id=obj.id).count()
+        return Sponsor.query.filter_by(event_id=obj.id, deleted_at=None).count()


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5845 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
- The number of sessions being returned in the methods(based on their state) also included the ones which have been deleted. This fix alludes to filtering out these deleted sessions which in turn give the correct amount of speakers.
 
#### Changes proposed in this pull request:

- Modified queries to check for `deleted_at` field for the correct count.

