### PR TITLE
fix: Fetch correct paypal credentials when in production

### DIFF
--- a/app/api/helpers/payment.py
+++ b/app/api/helpers/payment.py
@@ -136,20 +136,24 @@ class PayPalPaymentsManager(object):
         Configure the paypal sdk
         :return: Credentials
         """
-        # Use Sandbox by default.
         settings = get_settings()
-        paypal_mode = 'sandbox'
-        paypal_client = settings.get('paypal_sandbox_client', None)
-        paypal_secret = settings.get('paypal_sandbox_secret', None)
+        # Use Sandbox by default.
+        paypal_mode = settings.get('paypal_mode',
+                                   'live' if (settings['app_environment'] == Environment.PRODUCTION) else 'sandbox')
+        paypal_key = None
+        if paypal_mode == 'sandbox':
+            paypal_key = 'paypal_sandbox'
+        elif paypal_mode == 'live':
+            paypal_key = 'paypal'
 
-        # Switch to production if paypal_mode is production.
-        if settings['paypal_mode'] == Environment.PRODUCTION:
-            paypal_mode = 'live'
-            paypal_client = settings.get('paypal_client', None)
-            paypal_secret = settings.get('paypal_secret', None)
+        if not paypal_key:
+            raise ConflictException({'pointer': ''}, "Paypal Mode must be 'live' or 'sandbox'")
+
+        paypal_client = settings.get(f'{paypal_key}_client', None)
+        paypal_secret = settings.get(f'{paypal_key}_secret', None)
 
         if not paypal_client or not paypal_secret:
-            raise ConflictException({'pointer': ''}, "Payments through Paypal hasn't been configured on the platform")
+            raise ConflictException({'pointer': ''}, "Payments through Paypal have not been configured on the platform")
 
         paypalrestsdk.configure({
             "mode": paypal_mode,


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5851 

Ensures correct variables are used in comparisons which determine the mode of PayPal payments.