### PR TITLE
fix: make paypal helper syntax backward compatible

### DIFF
--- a/app/api/helpers/payment.py
+++ b/app/api/helpers/payment.py
@@ -149,8 +149,8 @@ class PayPalPaymentsManager(object):
         if not paypal_key:
             raise ConflictException({'pointer': ''}, "Paypal Mode must be 'live' or 'sandbox'")
 
-        paypal_client = settings.get(f'{paypal_key}_client', None)
-        paypal_secret = settings.get(f'{paypal_key}_secret', None)
+        paypal_client = settings.get('{}_client'.format(paypal_key), None)
+        paypal_secret = settings.get('{}_secret'.format(paypal_key), None)
 
         if not paypal_client or not paypal_secret:
             raise ConflictException({'pointer': ''}, "Payments through Paypal have not been configured on the platform")


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5855 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
This makes sure that the server doesn't throw error on python 3.5 or less
