### PR TITLE
fix: adds migration to change type of gender field in custom form to select

### DIFF
--- a/migrations/versions/6f7bfad3f54_update_gender_type_in_custom_form.py
+++ b/migrations/versions/6f7bfad3f54_update_gender_type_in_custom_form.py
@@ -1,0 +1,27 @@
+"""Update gender field in custom form from text to select
+
+Revision ID: 6f7b6fad3f54
+Revises: 6f7b6fad3f53
+Create Date: 2019-05-17 10:30:57.129985
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy_utils
+
+
+# revision identifiers, used by Alembic.
+revision = '6f7b6fad3f54'
+down_revision = '6f7b6fad3f53'
+
+
+def upgrade():
+    op.execute("UPDATE custom_forms SET type = 'select' where field_identifier = 'gender';",
+               execution_options=None)
+    
+
+
+def downgrade():
+    op.execute("UPDATE custom_forms SET type = 'text' where field_identifier = 'gender';",
+               execution_options=None)


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Related issue - https://github.com/fossasia/open-event-frontend/issues/1860
Reference : https://github.com/fossasia/open-event-frontend/pull/2917#issuecomment-492768746

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
We are now changing type of `gender` field of custom form to `select`. This migration ensures changing the type of `gender` field of already created events to `select`.

#### Changes proposed in this pull request:
 - Adds migration file to update type of gender field of past events to select
