### PR TITLE
fix: Add completed_at date for no charge orders

### DIFF
--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -139,6 +139,8 @@ class OrdersListPost(ResourceList):
 
         # send e-mail and notifications if the order status is completed
         if order.status == 'completed':
+            if order.payment_mode in ['free', 'bank', 'cheque', 'onsite']:
+                order.completed_at = datetime.utcnow()
             send_email_to_attendees(order, current_user.id)
             send_notif_to_attendees(order, current_user.id)
 
@@ -308,6 +310,8 @@ class OrderDetail(ResourceDetail):
             delete_related_attendees_for_order(order)
 
         elif order.status == 'completed':
+            if order.payment_mode in ['free', 'bank', 'cheque', 'onsite']:
+                order.completed_at = datetime.utcnow()
             send_email_to_attendees(order, current_user.id)
             send_notif_to_attendees(order, current_user.id)
 


### PR DESCRIPTION
Fixes #5913 


#### Short description of what this resolves:
Resolves the issue where only paid orders were assigned a completed_at date, now orders which do not involve charges will have a valid completion timestamp too.

