### PR TITLE
fix: update scheduler time constraint for pending tickets

### DIFF
--- a/app/api/helpers/order.py
+++ b/app/api/helpers/order.py
@@ -30,13 +30,13 @@ def delete_related_attendees_for_order(order):
 
 def set_expiry_for_order(order, override=False):
     """
-    Expire the order after the time slot(10 minutes) if the order is pending.
+    Expire the order after the time slot(10 minutes) if the order is initializing.
     Also expires the order if we want to expire an order regardless of the state and time.
     :param order: Order to be expired.
     :param override: flag to force expiry.
     :return:
     """
-    if order and not order.paid_via and (override or (order.status == 'pending' and (
+    if order and not order.paid_via and (override or (order.status == 'initializing' and (
                 order.created_at +
                 timedelta(minutes=order.event.order_expiry_time)) < datetime.now(timezone.utc))):
             order.status = 'expired'

--- a/app/api/helpers/scheduled_jobs.py
+++ b/app/api/helpers/scheduled_jobs.py
@@ -146,6 +146,6 @@ def expire_pending_tickets_after_one_day():
     from app import current_app as app
     with app.app_context():
         db.session.query(Order).filter(Order.status == 'pending',
-                                       (datetime.datetime.today() - Order.created_at).days > 1).\
+                                       (datetime.datetime.today() - Order.created_at).days > 3).\
                                        update({'status': 'expired'})
         db.session.commit()

--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -139,7 +139,7 @@ class OrdersListPost(ResourceList):
 #             TicketingManager.calculate_update_amount(order)
 
         # send e-mail and notifications if the order status is completed
-        if order.status == 'completed':
+        if order.status == 'completed' or order.status == 'placed':
             # fetch tickets attachment
             order_identifier = order.identifier
 
@@ -322,7 +322,7 @@ class OrderDetail(ResourceDetail):
             # delete the attendees so that the tickets are unlocked.
             delete_related_attendees_for_order(order)
 
-        elif order.status == 'completed':
+        elif order.status == 'completed' or order.status == 'placed':
 
             # Send email to attendees with invoices and tickets attached
             order_identifier = order.identifier

--- a/app/api/schema/orders.py
+++ b/app/api/schema/orders.py
@@ -68,7 +68,10 @@ class OrderSchema(SoftDeletionSchema):
     exp_month = fields.Str(dump_only=True)
     exp_year = fields.Str(dump_only=True)
     last4 = fields.Str(dump_only=True)
-    status = fields.Str(validate=validate.OneOf(choices=["pending", "cancelled", "completed", "placed", "expired"]))
+    status = fields.Str(
+        validate=validate.OneOf(
+            choices=["initializing", "pending", "cancelled", "completed", "placed", "expired"]
+        ))
     discount_code_id = fields.Str(allow_none=True)
     payment_url = fields.Str(dump_only=True)
     cancel_note = fields.Str(allow_none=True)

--- a/app/factories/order.py
+++ b/app/factories/order.py
@@ -13,4 +13,4 @@ class OrderFactory(factory.alchemy.SQLAlchemyModelFactory):
     event = factory.RelatedFactory(EventFactoryBasic)
     event_id = 1
     payment_mode = 'free'
-    status = 'pending'
+    status = 'initializing'

--- a/tests/all/integration/api/helpers/test_csv_jobs_util.py
+++ b/tests/all/integration/api/helpers/test_csv_jobs_util.py
@@ -25,7 +25,7 @@ class TestExportCSV(OpenEventTestCase):
             test_order = OrderFactory()
             test_order.amount = 2
             field_data = export_orders_csv([test_order])
-            self.assertEqual(field_data[1][2], 'pending')
+            self.assertEqual(field_data[1][2], 'initializing')
             self.assertEqual(field_data[1][4], '2')
 
     def test_export_attendees_csv(self):

--- a/tests/all/integration/api/helpers/test_order.py
+++ b/tests/all/integration/api/helpers/test_order.py
@@ -37,7 +37,7 @@ class TestOrderUtilities(OpenEventTestCase):
             event = EventFactoryBasic()
             obj.event = event
             set_expiry_for_order(obj)
-            self.assertEqual(obj.status, 'pending')
+            self.assertEqual(obj.status, 'initializing')
 
     def test_should_delete_related_attendees(self):
         """Method to test to delete related attendees of an event"""


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes https://github.com/fossasia/open-event-frontend/issues/2951

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Tickets that are unpaid are showing up as placed. Expected: Should show up as "Pending" and Expire after 3 days

#### Changes proposed in this pull request:
 - update scheduler time constraint
 - ensure that placed order also gets similar completed_at updation, mailing and notification as it was getting earlier.