### PR TITLE
fix: Fix session proposal email link

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -54,7 +54,7 @@ class SessionListPost(ResourceList):
             organizer_email = organizer.email
             frontend_url = get_settings()['frontend_url']
             event = session.event
-            link = "{}/events/{}/sessions/{}"\
+            link = "{}events/{}/sessions/{}"\
                 .format(frontend_url, event.identifier, session.id)
             send_email_new_session(organizer_email, event_name, link)
             send_notif_new_session_organizer(organizer, event_name, link, session.id)

--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -20,6 +20,7 @@ from app.models.track import Track
 from app.models.user import User
 from app.models.session_speaker_link import SessionsSpeakersLink
 from app.settings import get_settings
+from app.api.helpers.files import make_frontend_url
 
 
 class SessionListPost(ResourceList):
@@ -54,8 +55,8 @@ class SessionListPost(ResourceList):
             organizer_email = organizer.email
             frontend_url = get_settings()['frontend_url']
             event = session.event
-            link = "{}events/{}/sessions/{}"\
-                .format(frontend_url, event.identifier, session.id)
+            link = make_frontend_url("/events/{}/sessions/{}"
+                                     .format(event.identifier, session.id))
             send_email_new_session(organizer_email, event_name, link)
             send_notif_new_session_organizer(organizer, event_name, link, session.id)
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5976 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
There is an extra leading slash present which gives a wrong url link to the new session proposal.
This fix removes the leading slash for it.
#### Changes proposed in this pull request:

- Fixes the buggy link for sessions proposal.

