### PR TITLE
fix: throw HTTP 400 on short password during signup

### DIFF
--- a/app/api/helpers/exceptions.py
+++ b/app/api/helpers/exceptions.py
@@ -31,3 +31,11 @@ class MethodNotAllowed(JsonApiException):
     """
     title = "Method Not Allowed"
     status = 405
+
+
+class BadRequest(JsonApiException):
+    """
+    Default class to throw HTTP 400 Exception
+    """
+    title = 'Bad Request'
+    status = 400

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -9,7 +9,7 @@ import urllib.error
 from app import get_settings
 from app.api.bootstrap import api
 from app.api.helpers.db import safe_query, get_count
-from app.api.helpers.exceptions import ConflictException, UnprocessableEntity, ForbiddenException
+from app.api.helpers.exceptions import ConflictException, ForbiddenException, BadRequest
 from app.api.helpers.files import create_save_image_sizes, make_frontend_url
 from app.api.helpers.mail import send_email_confirmation, send_email_change_user_email, send_email_with_action
 from app.api.helpers.permission_manager import has_access
@@ -48,8 +48,8 @@ class UserList(ResourceList):
         :return:
         """
         if len(data['password']) < 8:
-            raise UnprocessableEntity({'source': '/data/attributes/password'},
-                                       'Password should be at least 8 characters long')
+            raise BadRequest({'source': '/data/attributes/password'},
+                             'Password should be at least 8 characters long')
         if db.session.query(User.id).filter_by(email=data['email'].strip()).scalar() is not None:
             raise ConflictException({'pointer': '/data/attributes/email'}, "Email already exists")
 

--- a/tests/all/integration/api/helpers/test_exceptions.py
+++ b/tests/all/integration/api/helpers/test_exceptions.py
@@ -1,7 +1,8 @@
 import unittest
 
 from tests.all.integration.utils import OpenEventTestCase
-from app.api.helpers.exceptions import UnprocessableEntity, ConflictException, ForbiddenException, MethodNotAllowed
+from app.api.helpers.exceptions import UnprocessableEntity, ConflictException, ForbiddenException, MethodNotAllowed, \
+                                       BadRequest
 from tests.all.integration.setup_database import Setup
 
 
@@ -28,6 +29,10 @@ class TestExceptionsHelperValidation(OpenEventTestCase):
         # Method Not Allowed Exception
         with self.assertRaises(MethodNotAllowed):
             raise MethodNotAllowed({'source': ''}, "Method Not Allowed")
+
+        # Bad Request Exception
+        with self.assertRaises(BadRequest):
+            raise BadRequest({'source': ''}, "Bad Request")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5989 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
For short length of the password, the error is HTTP 422, It should be HTTP 400

#### Changes proposed in this pull request:
Adds a new exception - `BadRequest` to raise HTTP 400 error


