### PR TITLE
feat: adds checks for owner role invite

### DIFF
--- a/app/api/helpers/role_invite.py
+++ b/app/api/helpers/role_invite.py
@@ -1,0 +1,25 @@
+import logging
+from app.models import db
+from app.models.role_invite import RoleInvite
+
+logger = logging.getLogger(__name__)
+
+
+def delete_previous_uer(uer):
+    """
+    delete previous owner before adding a new one
+    :param uer: User Event Role to be deleted.
+    :return:
+    """
+    role_invite = db.session.query(RoleInvite).filter_by(
+        email=uer.user.email, event_id=uer.event_id, role_name='owner', status='accepted'
+        ).first()
+
+    if role_invite:
+        db.session.delete(role_invite)
+    db.session.delete(uer)
+    try:
+        db.session.commit()
+    except Exception:
+        logger.exception('UER or Role Invite delete exception!')
+        db.session.rollback()

--- a/app/api/role_invites.py
+++ b/app/api/role_invites.py
@@ -11,6 +11,7 @@ from app.api.helpers.mail import send_email_role_invite, send_user_email_role_in
 from app.api.helpers.notification import send_notif_event_role
 from app.api.helpers.permission_manager import has_access
 from app.api.helpers.query import event_query
+from app.api.helpers.role_invite import delete_previous_uer
 from app.api.helpers.utilities import require_relationship
 from app.api.schema.role_invites import RoleInviteSchema
 from app.models import db
@@ -41,6 +42,16 @@ class RoleInviteListPost(ResourceList):
         if not has_access('is_organizer', event_id=data['event']):
             raise ForbiddenException({'source': ''}, 'Organizer access is required.')
 
+    def before_create_object(self, data, view_kwargs):
+        """
+        before create object method for RoleInviteListPost Class
+        :param data:
+        :param view_kwargs:
+        :return:
+        """
+        if data['role_name'] == 'owner' and not has_access('is_owner', event_id=data['event']):
+            raise ForbiddenException({'source': ''}, 'Owner access is required.')
+
     def after_create_object(self, role_invite, data, view_kwargs):
         """
         after create object method for role invite links
@@ -67,6 +78,7 @@ class RoleInviteListPost(ResourceList):
     data_layer = {'session': db.session,
                   'model': RoleInvite,
                   'methods': {
+                      'before_create_object': before_create_object,
                       'after_create_object': after_create_object
                   }}
 
@@ -116,6 +128,8 @@ class RoleInviteDetail(ResourceDetail):
                                                                                                 user_id=user.id):
                 raise UnprocessableEntity({'source': ''},
                                           "Status can be updated only by event organizer or user hiself")
+        if 'role_name' in data and data['role_name'] == 'owner' and not has_access('is_owner', event_id=data['event']):
+            raise ForbiddenException({'source': ''}, 'Owner access is required.')
         if not user and not has_access('is_organizer', event_id=role_invite.event_id):
             raise UnprocessableEntity({'source': ''}, "User not registered")
         if not has_access('is_organizer', event_id=role_invite.event_id) and (len(list(data.keys())) > 1 or
@@ -159,7 +173,12 @@ def accept_invite():
         event = Event.query.filter_by(id=role_invite.event_id).first()
         uer = UsersEventsRoles.query.filter_by(user=user).filter_by(
             event=event).filter_by(role=role).first()
+
         if not uer:
+            if role_invite.role_name == 'owner':
+                past_owner = UsersEventsRoles.query.filter_by(event=event, role=role).first()
+                if past_owner:
+                    delete_previous_uer(past_owner)
             role_invite.status = "accepted"
             save_to_db(role_invite, 'Role Invite Accepted')
             uer = UsersEventsRoles(user, event, role)


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5890 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Changes proposed in this pull request:
- Only owner of an event can send role-invite for owner to other user
- Ensures that when an owner role-invite is accepted, the previous owner is deleted so that there can be a single owner of an event. Also, previous owner role-invite and new owner's last role-invite is also deleted