### PR TITLE
fix: Ticket downloads for multi-attendee orders

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -304,12 +304,10 @@ def ticket_attendee_authorized(order_identifier):
     if current_user:
         try:
             order = Order.query.filter_by(identifier=order_identifier).first()
-            user_id = order.user.id
-            event_id = order.event.id
         except NoResultFound:
             return NotFoundError({'source': ''}, 'This ticket is not associated with any order').respond()
-        if current_user.id == user_id or current_user.is_organizer(event_id):
-            key = UPLOAD_PATHS['pdf']['ticket_attendee'].format(identifier=order_identifier)
+        if current_user.can_download_tickets(order):
+            key = UPLOAD_PATHS['pdf']['tickets_all'].format(identifier=order_identifier)
             file_path = '../generated/tickets/{}/{}/'.format(key, generate_hash(key)) + order_identifier + '.pdf'
             try:
                 return return_tickets(file_path, order_identifier)

--- a/app/api/helpers/order.py
+++ b/app/api/helpers/order.py
@@ -53,7 +53,7 @@ def create_pdf_tickets_for_holder(order):
     """
     if order.status == 'completed' or order.status == 'placed':
         pdf = create_save_pdf(render_template('pdf/ticket_purchaser.html', order=order),
-                              UPLOAD_PATHS['pdf']['ticket_attendee'],
+                              UPLOAD_PATHS['pdf']['tickets_all'],
                               dir_path='/static/uploads/pdf/tickets/', identifier=order.identifier, upload_dir='generated/tickets/')
 
         order.tickets_pdf_url = pdf

--- a/app/api/helpers/storage.py
+++ b/app/api/helpers/storage.py
@@ -80,7 +80,8 @@ UPLOAD_PATHS = {
     },
     'pdf': {
         'ticket_attendee': 'attendees/tickets/pdf/{identifier}',
-        'order': 'orders/invoices/pdf/{identifier}'
+        'order': 'orders/invoices/pdf/{identifier}',
+        'tickets_all': 'orders/tickets/pdf/{identifier}'
     }
 }
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -360,6 +360,12 @@ class User(SoftDeletionModel):
             return False
         return perm.panel_name
 
+    def can_download_tickets(self, order):
+        permissible_users = [holder.id for holder in order.ticket_holders] + [order.user.id]
+        if self.is_staff or self.is_organizer(order.event.id) or self.id in permissible_users:
+            return True
+        return False
+
     def can_access_panel(self, panel_name):
         """
         Check if user can access an Admin Panel


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6091 

#### Short description of what this resolves:
There were several issues at storage and permission level which prevented ticket downloads for multiple attendees.

- There are separate ticket PDFs generated for all ticket holders, and then individual ticket holders.
- These files were overwriting each other, and as such only the last attendee was present in the generated ticket
- Admin, or ticket holders were not being allowed to download tickets due to wrong logical implementation on permission checks

#### Changes proposed in this pull request:

- Create a new path for combined tickets
- Move away permission control to user model 
- Amend permission control to allow admin, and ticket holders to download tickets.

