### PR TITLE
fix: Query for speakers properly for after event cron job

### DIFF
--- a/app/api/helpers/scheduled_jobs.py
+++ b/app/api/helpers/scheduled_jobs.py
@@ -14,6 +14,7 @@ from app.models import db
 from app.models.event import Event
 from app.models.event_invoice import EventInvoice
 from app.models.order import Order
+from app.models.speaker import Speaker
 from app.models.session import Session
 from app.models.ticket import Ticket
 from app.models.ticket_fee import get_fee
@@ -33,7 +34,7 @@ def send_after_event_mail():
         upcoming_event_links += "</ul>"
         for event in events:
             organizers = get_user_event_roles_by_role_name(event.id, 'organizer')
-            speakers = get_user_event_roles_by_role_name(event.id, 'speaker')
+            speakers = Speaker.query.filter_by(event_id=event.id, deleted_at=None).all()
             current_time = datetime.datetime.now(pytz.timezone(event.timezone))
             time_difference = current_time - event.ends_at
             time_difference_minutes = (time_difference.days * 24 * 60) + \


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6099 

Queries speaker model by matching event id, instead of roles, since there is no role for speaker in the system.