### PR TITLE
feat: add event date to response of order for admin sales revenues (formerly fees)

### DIFF
--- a/app/api/admin_sales/fees.py
+++ b/app/api/admin_sales/fees.py
@@ -25,7 +25,7 @@ class AdminSalesFeesSchema(Schema):
     maximum_fee = fields.Float(attribute='maximum_fee')
     revenue = fields.Method('calc_revenue')
     ticket_count = fields.Method('calc_ticket_count')
-    event_date = fields.Method('get_eventdate')
+    event_date = fields.Method('get_event_date')
 
     @staticmethod
     def calc_ticket_count(obj):
@@ -39,7 +39,7 @@ class AdminSalesFeesSchema(Schema):
             [o.get_revenue() for o in obj.orders if o.status == 'completed'])
 
     @staticmethod
-    def get_eventdate(obj):
+    def get_event_date(obj):
         return obj.starts_at.isoformat()
 
 

--- a/app/api/admin_sales/fees.py
+++ b/app/api/admin_sales/fees.py
@@ -25,6 +25,7 @@ class AdminSalesFeesSchema(Schema):
     maximum_fee = fields.Float(attribute='maximum_fee')
     revenue = fields.Method('calc_revenue')
     ticket_count = fields.Method('calc_ticket_count')
+    event_date = fields.Method('get_eventdate')
 
     @staticmethod
     def calc_ticket_count(obj):
@@ -36,6 +37,10 @@ class AdminSalesFeesSchema(Schema):
         """Returns total revenues of all completed orders for the given event"""
         return sum(
             [o.get_revenue() for o in obj.orders if o.status == 'completed'])
+
+    @staticmethod
+    def get_eventdate(obj):
+        return obj.starts_at.isoformat()
 
 
 class AdminSalesFeesList(ResourceList):


### PR DESCRIPTION
Reference: https://github.com/fossasia/open-event-frontend/issues/3173

#### Short description of what this resolves:
Currently admin sales fees api response doesn't contains event start date. 

#### Changes proposed in this pull request:

- Add event start date to the schema of admin sales fee.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.
