### PR TITLE
feat: add owner to the api response of admin-sales-fee.

### DIFF
--- a/app/api/admin_sales/fees.py
+++ b/app/api/admin_sales/fees.py
@@ -27,7 +27,7 @@ class AdminSalesFeesSchema(Schema):
     revenue = fields.Method('calc_revenue')
     ticket_count = fields.Method('calc_ticket_count')
     event_date = fields.Method('get_event_date')
-    owner = fields.Nested(UserSchemaPublic)
+    organizers = fields.List(cls_or_instance=fields.Nested(UserSchemaPublic), load_only=True, allow_none=True)
 
     @staticmethod
     def calc_ticket_count(obj):

--- a/app/api/admin_sales/fees.py
+++ b/app/api/admin_sales/fees.py
@@ -6,6 +6,7 @@ from app.api.bootstrap import api
 from app.api.helpers.utilities import dasherize
 from app.models import db
 from app.models.event import Event
+from app.api.schema.users import UserSchemaPublic
 
 
 class AdminSalesFeesSchema(Schema):
@@ -26,6 +27,7 @@ class AdminSalesFeesSchema(Schema):
     revenue = fields.Method('calc_revenue')
     ticket_count = fields.Method('calc_ticket_count')
     event_date = fields.Method('get_event_date')
+    owner = fields.Nested(UserSchemaPublic)
 
     @staticmethod
     def calc_ticket_count(obj):


### PR DESCRIPTION
Reference: https://github.com/fossasia/open-event-frontend/issues/3173

The issue says organizers, the organizers for my created local events were coming empty, also there can be a lot of organizers which might make the table of revenue section cluttered, since the owner is only one, I guess it's better to show event owner in the table.

<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

#### Short description of what this resolves:
Currently the owner of event isn't returned in the api.

#### Changes proposed in this pull request:

- Add owner of the event in the api response

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.
