### PR TITLE
fix: Removed currency symbol filter

### DIFF
--- a/app/templates/pdf/order_invoice.html
+++ b/app/templates/pdf/order_invoice.html
@@ -124,7 +124,7 @@
                                     {{ order.status | capitalize }}
                                 {% endif %}<br>
                                 {{ order.tickets_count }}<br>
-                                {{ event.payment_currency | currency_symbol }}{{ order.amount | money }}<br>
+                                {{ event.payment_currency }}{{ order.amount | money }}<br>
                                 {% if order.status == 'completed' %}
                                     {{ order.paid_via | capitalize }}
                                 {% else %}
@@ -183,18 +183,18 @@
                     {% for order_ticket in order_tickets %}
                       <tr>
                         <td style="text-align:center">{{ order_ticket.ticket.name }}</td>
-                        <td style="text-align:center">{{ event.payment_currency | currency_symbol }}{{ order_ticket.ticket.price }}</td>
+                        <td style="text-align:center">{{ event.payment_currency }}{{ order_ticket.ticket.price }}</td>
                         <td style="text-align:center">{{ order_ticket.quantity }}</td>
-                        <td style="text-align:center">{{ event.payment_currency | currency_symbol }}{{ order_ticket.quantity*order_ticket.ticket.price }}</td>
+                        <td style="text-align:center">{{ event.payment_currency }}{{ order_ticket.quantity*order_ticket.ticket.price }}</td>
                         {% if tax %}
                         <td style="text-align:center">{{ tax.rate }}%</td>
                         {% else %}
                         <td style="text-align:center">{{ ("0%") }}</td>
                         {% endif %}
                         {% if tax %}
-                        <td style="text-align:center">{{ event.payment_currency | currency_symbol }}{{ tax.rate*order_ticket.ticket.price/100 }}</td>
+                        <td style="text-align:center">{{ event.payment_currency }}{{ tax.rate*order_ticket.ticket.price/100 }}</td>
                         {% else %}
-                        <td style="text-align:center">{{ event.payment_currency | currency_symbol }}0</td>
+                        <td style="text-align:center">{{ event.payment_currency }}0</td>
                         {% endif %}
                       </tr>
                     {% endfor %}
@@ -204,7 +204,7 @@
                         <td></td>
                         <td></td>
                         <td><b>Grand Total</b></td>
-                        <td> {{ event.payment_currency | currency_symbol }}{{ order.amount | money }}</td>
+                        <td> {{ event.payment_currency }}{{ order.amount | money }}</td>
                     </tr>
                     </tbody>
                   </table>


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6018 

#### Short description of what this resolves:
Removes the currency symbol template filter which was not able to render most of the currency symbols due to a render issue with PISA

#### Changes proposed in this pull request:

- Replaced currency symbols with 3-letter conventions to fix the render issue

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.