### PR TITLE
fix: returns queried feedback only

### DIFF
--- a/app/api/feedbacks.py
+++ b/app/api/feedbacks.py
@@ -14,6 +14,7 @@ from app.models import db
 from app.models.feedback import Feedback
 from app.models.event import Event
 from app.models.session import Session
+from app.models.user import User
 
 
 class FeedbackListPost(ResourceList):
@@ -72,7 +73,17 @@ class FeedbackList(ResourceList):
         :return:
         """
         query_ = self.session.query(Feedback)
-        query_ = event_query(self, query_, view_kwargs)
+        if view_kwargs.get('user_id'):
+            # feedbacks under an user
+            user = safe_query(self, User, 'id', view_kwargs['user_id'], 'user_id')
+            query_ = query_.join(User, User.id == Feedback.user_id).filter(User.id == user.id)
+        elif view_kwargs.get('session_id'):
+            # feedbacks under a session
+            session = safe_query(self, Session, 'id', view_kwargs['session_id'], 'session_id')
+            query_ = query_.join(Session, Session.id == Feedback.session_id).filter(Session.id == session.id)
+        else:
+            # feedbacks under an event
+            query_ = event_query(self, query_, view_kwargs)
         return query_
 
     view_kwargs = True

--- a/app/api/schema/users.py
+++ b/app/api/schema/users.py
@@ -90,7 +90,7 @@ class UserSchema(UserSchemaPublic):
         many=True,
         type_='notification')
     feedbacks = Relationship(
-        attribute='feedbacks',
+        attribute='feedback',
         self_view='v1.user_feedback',
         self_view_kwargs={'id': '<id>'},
         related_view='v1.feedback_list',


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6149 

#### Short description of what this resolves:
feedback query always returns all the feedbacks

#### Changes proposed in this pull request:
- returns feedback according to query params i.e. `user_id` or `session_id`

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
