### PR TITLE
fix: allows hard delete for feedbacks

### DIFF
--- a/app/api/helpers/feedback.py
+++ b/app/api/helpers/feedback.py
@@ -1,0 +1,18 @@
+import logging
+from app.models import db
+
+logger = logging.getLogger(__name__)
+
+
+def delete_feedback(feedback):
+    """
+    Delete the feedback if rating is zero
+    :param feedback: Feedback to be deleted
+    :return:
+    """
+    db.session.delete(feedback)
+    try:
+        db.session.commit()
+    except Exception:
+        logger.exception('Feedback delete exception!')
+        db.session.rollback()

--- a/app/api/schema/feedbacks.py
+++ b/app/api/schema/feedbacks.py
@@ -23,7 +23,7 @@ class FeedbackSchema(SoftDeletionSchema):
         inflect = dasherize
 
     id = fields.Str(dump_only=True)
-    rating = fields.Float(required=True, validate=Range(min=0, max=5))
+    rating = fields.Float(required=True, validate=Range(min=1, max=5))
     comment = fields.Str(required=False)
     event = Relationship(attribute='event',
                          self_view='v1.feedback_event',


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6153 

#### Short description of what this resolves:
Currently there is hard delete for feedback. 

#### Changes proposed in this pull request:
- Hard deletes the feedback if deleted_at is not NULL
- Changes range from `0-5` to `1-5` for rating

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
