### PR TITLE
feat: add a resend email route for organizers

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -396,6 +396,7 @@ def resend_emails():
             return jsonify(status=True, message="Verification emails for order : {} has been sent succesfully".
                            format(order_identifier))
         else:
-            return jsonify(status=False, message="Only placed and complete orders are verified")
+            return UnprocessableEntityError({'source': 'data/order'},
+                                            "Only placed and completed orders have confirmation").respond()
     else:
-        raise ForbiddenError({'source': ''}, "Co-Organizer Access Required").respond()
+        return ForbiddenError({'source': ''}, "Co-Organizer Access Required").respond()

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -16,14 +16,16 @@ from app.api.helpers.storage import generate_hash
 
 from app import get_settings
 from app import limiter
-from app.api.helpers.db import save_to_db, get_count
+from app.api.helpers.db import save_to_db, get_count, safe_query
 from app.api.helpers.errors import ForbiddenError, UnprocessableEntityError, NotFoundError, BadRequestError
 from app.api.helpers.files import make_frontend_url
+from app.api.helpers.mail import send_email_to_attendees
 from app.api.helpers.mail import send_email_with_action, \
     send_email_confirmation
 from app.api.helpers.notification import send_notification_with_action
 from app.api.helpers.third_party_auth import GoogleOAuth, FbOAuth, TwitterOAuth, InstagramOAuth
 from app.api.helpers.utilities import get_serializer, str_generator
+from app.api.helpers.permission_manager import has_access
 from app.models import db
 from app.models.order import Order
 from app.models.mail import PASSWORD_RESET, PASSWORD_CHANGE, \
@@ -363,3 +365,37 @@ def requires_basic_auth(f):
 def environment_details():
     envdump = EnvironmentDump(include_config=False)
     return envdump.dump_environment()
+
+
+@ticket_blueprint.route('/orders/resend-email', methods=['POST'])
+@limiter.limit(
+    '5/minute', key_func=lambda: request.json['data']['order'], error_message='Limit for this action exceeded'
+)
+@limiter.limit(
+    '60/minute', key_func=get_remote_address, error_message='Limit for this action exceeded'
+)
+def resend_emails():
+    """
+    Sends confirmation email for pending and completed orders on organizer request
+    :param order_identifier:
+    :return: JSON response if the email was succesfully sent
+    """
+    order_identifier = request.json['data']['order']
+    order = safe_query(db, Order, 'identifier', order_identifier, 'identifier')
+    if (has_access('is_coorganizer', event_id=order.event_id)):
+        if order.status == 'completed' or order.status == 'placed':
+            # fetch tickets attachment
+            order_identifier = order.identifier
+            key = UPLOAD_PATHS['pdf']['tickets_all'].format(identifier=order_identifier)
+            ticket_path = 'generated/tickets/{}/{}/'.format(key, generate_hash(key)) + order_identifier + '.pdf'
+            key = UPLOAD_PATHS['pdf']['order'].format(identifier=order_identifier)
+            invoice_path = 'generated/invoices/{}/{}/'.format(key, generate_hash(key)) + order_identifier + '.pdf'
+
+            # send email.
+            send_email_to_attendees(order=order, purchaser_id=current_user.id, attachments=[ticket_path, invoice_path])
+            return jsonify(status=True, message="Verification emails for order : {} has been sent succesfully".
+                           format(order_identifier))
+        else:
+            return jsonify(status=False, message="Only placed and complete orders are verified")
+    else:
+        raise ForbiddenError({'source': ''}, "Co-Organizer Access Required").respond()

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -369,7 +369,7 @@ def environment_details():
 
 @ticket_blueprint.route('/orders/resend-email', methods=['POST'])
 @limiter.limit(
-    '5/minute', key_func=lambda: request.json['data']['order'], error_message='Limit for this action exceeded'
+    '5/minute', key_func=lambda: request.json['data']['user'], error_message='Limit for this action exceeded'
 )
 @limiter.limit(
     '60/minute', key_func=get_remote_address, error_message='Limit for this action exceeded'

--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -153,10 +153,8 @@ class OrdersListPost(ResourceList):
 
             key = UPLOAD_PATHS['pdf']['order'].format(identifier=order_identifier)
             invoice_path = 'generated/invoices/{}/{}/'.format(key, generate_hash(key)) + order_identifier + '.pdf'
-
             # send email and notifications.
             send_email_to_attendees(order=order, purchaser_id=current_user.id, attachments=[ticket_path, invoice_path])
-
             send_notif_to_attendees(order, current_user.id)
 
             if order.payment_mode in ['free', 'bank', 'cheque', 'onsite']:
@@ -535,3 +533,30 @@ def omise_checkout(order_identifier):
         logging.info(f"Successful charge: {charge.id}.  Order ID: {order_identifier}")
 
         return redirect(make_frontend_url('orders/{}/view'.format(order_identifier)))
+
+
+@order_misc_routes.route('/orders/<string:order_identifier>/resend-email', methods=['POST'])
+def resend_emails(order_identifier):
+    """
+    Sends confirmation email for pending and completed orders on organizer request
+    :param order_identifier:
+    :return: JSON response if the email was succesfully sent
+    """
+    order = safe_query(db, Order, 'identifier', order_identifier, 'identifier')
+    if (has_access('is_coorganizer', event_id=order.event_id)):
+        if order.status == 'completed' or order.status == 'placed':
+            # fetch tickets attachment
+            order_identifier = order.identifier
+            key = UPLOAD_PATHS['pdf']['tickets_all'].format(identifier=order_identifier)
+            ticket_path = 'generated/tickets/{}/{}/'.format(key, generate_hash(key)) + order_identifier + '.pdf'
+            key = UPLOAD_PATHS['pdf']['order'].format(identifier=order_identifier)
+            invoice_path = 'generated/invoices/{}/{}/'.format(key, generate_hash(key)) + order_identifier + '.pdf'
+
+            # send email.
+            send_email_to_attendees(order=order, purchaser_id=current_user.id, attachments=[ticket_path, invoice_path])
+            return jsonify(status=True, message="Verification emails for order : {} has been sent succesfully".
+                           format(order_identifier))
+        else:
+            return jsonify(status=False, message="Only placed and complete orders are verified")
+    else:
+        raise ForbiddenException({'source': ''}, "Co-Organizer Access Required")


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6162 

#### Short description of what this resolves:
This adds an endpoint which triggers re sending email confirmation for tickets

#### Changes proposed in this pull request:

- Ensures that only organisers and co organisers have ability to resend the emails. 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.
