### PR TITLE
fix: allow event managers to delete expired orders

### DIFF
--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -282,7 +282,7 @@ class OrderDetail(ResourceDetail):
                 # Order created from the public pages.
                 for element in data:
                     if data[element] and data[element] != getattr(order, element, None):
-                        if element != 'status':
+                        if element != 'status' and element != 'deleted_at':
                             raise ForbiddenException({'pointer': 'data/{}'.format(element)},
                                                      "You cannot update {} of an order".format(element))
                         elif element == 'status' and order.amount and order.status == 'completed':


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6177 

#### Short description of what this resolves:

Allows managers to delete expired orders. 
