### PR TITLE
fix: allow coorganizer, owner to download invoice/tickets for event orders

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -387,7 +387,7 @@ class User(SoftDeletionModel):
 
     def can_download_tickets(self, order):
         permissible_users = [holder.id for holder in order.ticket_holders] + [order.user.id]
-        if self.is_staff or self.is_organizer(order.event.id) or self.id in permissible_users:
+        if self.is_staff or self.has_event_access(order.event.id) or self.id in permissible_users:
             return True
         return False
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6181 

Tweaks the config to allow the owners and coorganizers to download the ticket as well.