### PR TITLE
fix: order deletion triggers emails

### DIFF
--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -323,15 +323,14 @@ class OrderDetail(ResourceDetail):
         # create pdf tickets.
         create_pdf_tickets_for_holder(order)
 
-        if order.status == 'cancelled':
+        if order.status == 'cancelled' and order.deleted_at is None:
             send_order_cancel_email(order)
             send_notif_ticket_cancel(order)
 
             # delete the attendees so that the tickets are unlocked.
             delete_related_attendees_for_order(order)
 
-        elif order.status == 'completed' or order.status == 'placed':
-
+        elif (order.status == 'completed' or order.status == 'placed') and order.deleted_at is None:
             # Send email to attendees with invoices and tickets attached
             order_identifier = order.identifier
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes fossasia/open-event-frontend#3269

#### Short description of what this resolves:
Ensures that deletion of orders doesn't trigger notifications and emails

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.
