### PR TITLE
fix: removes discrepancies in cancelling order

### DIFF
--- a/app/api/helpers/notification.py
+++ b/app/api/helpers/notification.py
@@ -304,11 +304,15 @@ def send_notif_ticket_cancel(order):
     send_notification(
         user=order.event.owner,
         title=NOTIFS[TICKET_CANCELLED_ORGANIZER]['title'].format(
-            invoice_id=order.invoice_number
+            invoice_id=order.invoice_number,
+            event_name=order.event.name
         ),
         message=NOTIFS[TICKET_CANCELLED_ORGANIZER]['message'].format(
             cancel_note=order.cancel_note,
-            invoice_id=order.invoice_number
+            invoice_id=order.invoice_number,
+            event_name=order.event.name,
+            cancel_order_page=make_frontend_url('/events/{identifier}/tickets/orders/cancelled'
+                                                .format(identifier=order.event.identifier))
         )
     )
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6141

#### Short description of what this resolves:
There are discrepancies while cancelling order.

#### Changes proposed in this pull request:
- updates `send_notif_ticket_cancel` in `api/helpers/notification.py`
- updates the logic to raise error on field update in `api/orders.py`

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
