### PR TITLE
fix: Add citext extension in migration if not exists

### DIFF
--- a/migrations/versions/ba651e8ce9a3_lowercase_discount_code.py
+++ b/migrations/versions/ba651e8ce9a3_lowercase_discount_code.py
@@ -14,6 +14,7 @@ down_revision = '4bdb4809f519'
 
 
 def upgrade():
+    op.execute("create extension if not exists citext;", execution_options=None)
     op.execute("alter table discount_codes alter column code type citext;",
                execution_options=None)
     op.create_unique_constraint('uq_event_discount_code', 'discount_codes', ['event_id', 'code'])


### PR DESCRIPTION
Hotfix for #6187