### PR TITLE
fix: allows only owner and organizer to delete role-invites

### DIFF
--- a/app/api/role_invites.py
+++ b/app/api/role_invites.py
@@ -135,6 +135,11 @@ class RoleInviteDetail(ResourceDetail):
         if not has_access('is_organizer', event_id=role_invite.event_id) and (len(list(data.keys())) > 1 or
                                                                               'status' not in data):
             raise UnprocessableEntity({'source': ''}, "You can only change your status")
+        if data.get('deleted_at'):
+            if role_invite.role_name == 'owner' and not has_access('is_owner', event_id=role_invite.event_id):
+                raise ForbiddenException({'source': ''}, 'Owner access is required.')
+            if role_invite.role_name != 'owner' and not has_access('is_organizer', event_id=role_invite.event_id):
+                raise ForbiddenException({'source': ''}, 'Organizer access is required.')
 
     decorators = (api.has_permission('is_organizer', methods="DELETE", fetch="event_id", fetch_as="event_id",
                                      model=RoleInvite),)


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6152

#### Short description of what this resolves:
Currently, a user with coorganizer access to an event can delete other organizers/coorganizers/owners too. 

#### Changes proposed in this pull request:
- Allows only owner and organizers to delete role invites other than `owner` role. For `owner` role, user must have owner access to delete it

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
