### PR TITLE
fix: make billing info mandatory for paid orders

### DIFF
--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -63,6 +63,16 @@ def is_payment_valid(order, mode):
         return (order.paid_via == 'paypal') and order.transaction_id
 
 
+def check_billing_info(data):
+    if data.get('amount') > 0 and not data.get('is_billing_enabled'):
+        raise UnprocessableEntity({'pointer': '/data/attributes/is_billing_enabled'},
+                                  "Billing information is mandatory for paid orders")
+    if data.get('is_billing_enabled') and not (data.get('company') and data.get('address') and data.get('city') and
+                                               data.get('zip') and data.get('country')):
+        raise UnprocessableEntity({'pointer': '/data/attributes/is_billing_enabled'},
+                                  "Billing information incomplete")
+
+
 class OrdersListPost(ResourceList):
     """
     OrderListPost class for OrderSchema
@@ -96,6 +106,7 @@ class OrdersListPost(ResourceList):
         :param view_kwargs:
         :return:
         """
+        check_billing_info(data)
 
         free_ticket_quantity = 0
 
@@ -299,6 +310,7 @@ class OrderDetail(ResourceDetail):
         :param view_kwargs:
         :return:
         """
+        check_billing_info(data)
         if (not has_access('is_coorganizer', event_id=order.event_id)) and (not current_user.id == order.user_id):
             raise ForbiddenException({'pointer': ''}, "Access Forbidden")
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6137 

#### Short description of what this resolves:
Make billing information mandatory for paid orders

#### Changes proposed in this pull request:
- Adds checks in `before_create_object` and `before_update_object` in `api/orders.py`

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
