### PR TITLE
fix: state logic error in sessions.py

### DIFF
--- a/app/api/schema/sessions.py
+++ b/app/api/schema/sessions.py
@@ -54,7 +54,7 @@ class SessionSchema(SoftDeletionSchema):
                     {'pointer': '/data/attributes/starts-at'}, "starts-at should be after current date-time")
 
         if 'state' in data:
-            if data['state'] is not 'draft' or not 'pending':
+            if data['state'] not in ('draft', 'pending'):
                 if not has_access('is_coorganizer', event_id=data['event']):
                     return ForbiddenException({'source': ''}, 'Co-organizer access is required.')
 


### PR DESCRIPTION
> if data['state'] is not 'draft' or not 'pending':

The second half of this if statement is __always__ False because:
__python -c "print(not 'pending')"__`   `# --> False

The correct ways to write this line are:
```python
if data['state'] != 'draft' or data['state'] != 'pending':
# or better yet...
if data['state'] not in ('draft', 'pending'):  # LOL, codacy-bot seems to like this one.
```

<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
