### PR TITLE
ENH:Fix typo in the notification invitation message

### DIFF
--- a/app/api/helpers/system_notifications.py
+++ b/app/api/helpers/system_notifications.py
@@ -392,7 +392,7 @@ NOTIFS = {
     },
     EVENT_ROLE: {
         'title': u'Invitation to be {role_name} at {event_name}',
-        'message': u"You've been invited to be a <strong>{role_name}</strong>" +
+        'message': u"You've been invited to be an <strong>{role_name}</strong>" +
                    u" at <strong>{event_name}</strong>.",
         'recipient': 'User',
     },


### PR DESCRIPTION
Currently, one user gets the notification-You've been invited to be a attendee at TEST EVENT2.
But for attendees and for organizer, I changed it to- You've been invited to be an attendee at TEST EVENT2. according to standards.

Fixes #5872 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
