### PR TITLE
fix: Use correct kwarg for access-codes api

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -544,7 +544,7 @@ api.route(AccessCodeList, 'access_code_list', '/events/<int:event_id>/access-cod
           '/tickets/<int:ticket_id>/access-codes')
 api.route(AccessCodeDetail, 'access_code_detail', '/access-codes/<int:id>',
           '/events/<int:access_event_id>/access-codes/<code>',
-          '/events/<int:access_event_identifier>/access-codes/<code>',)
+          '/events/<access_event_identifier>/access-codes/<code>',)
 api.route(AccessCodeRelationshipRequired, 'access_code_event',
           '/access-codes/<int:id>/relationships/event')
 api.route(AccessCodeRelationshipOptional, 'access_code_user',

--- a/app/api/access_codes.py
+++ b/app/api/access_codes.py
@@ -115,7 +115,7 @@ class AccessCodeDetail(ResourceDetail):
 
         if kwargs.get('access_event_identifier'):
             event = safe_query(
-                db, Event, 'identifier', kwargs['discount_event_identifier'],
+                db, Event, 'identifier', kwargs['access_event_identifier'],
                 'event_identifier')
             kwargs['access_event_id'] = event.id
         if kwargs.get('code') and kwargs.get('access_event_id'):


### PR DESCRIPTION
Follow up on #6251 

Use the correct kwarg in the access codes API.