### PR TITLE
fix: Call before_get_method in methods

### DIFF
--- a/app/api/custom_forms.py
+++ b/app/api/custom_forms.py
@@ -88,7 +88,10 @@ class CustomFormDetail(ResourceDetail):
                   fetch_as="event_id", model=CustomForms, methods="PATCH,DELETE"), )
     schema = CustomFormSchema
     data_layer = {'session': db.session,
-                  'model': CustomForms}
+                  'model': CustomForms,
+                  'methods': {
+                      'before_get_object': before_get_object
+                  }}
 
 
 class CustomFormRelationshipRequired(ResourceRelationship):

--- a/app/api/custom_system_roles.py
+++ b/app/api/custom_system_roles.py
@@ -54,7 +54,10 @@ class CustomSystemRoleDetail(ResourceDetail):
     decorators = (api.has_permission('is_admin', methods="PATCH,DELETE"),)
     schema = CustomSystemRoleSchema
     data_layer = {'session': db.session,
-                  'model': CustomSysRole}
+                  'model': CustomSysRole,
+                  'methods': {
+                      'before_get_object': before_get_object
+                  }}
 
 
 class CustomSystemRoleRelationship(ResourceRelationship):

--- a/app/api/events.py
+++ b/app/api/events.py
@@ -580,6 +580,7 @@ class EventDetail(ResourceDetail):
                   'model': Event,
                   'methods': {
                       'before_update_object': before_update_object,
+                      'before_get_object': before_get_object,
                       'after_update_object': after_update_object,
                       'before_patch': before_patch
                   }}

--- a/app/api/feedbacks.py
+++ b/app/api/feedbacks.py
@@ -146,7 +146,10 @@ class FeedbackDetail(ResourceDetail):
     schema = FeedbackSchema
     data_layer = {'session': db.session,
                   'model': Feedback,
-                  'methods': {'before_update_object': before_update_object}}
+                  'methods': {
+                      'before_update_object': before_update_object,
+                      'before_get_object': before_get_object
+                  }}
 
 
 class FeedbackRelationship(ResourceRelationship):


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6272 

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [X] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [X] All the functions created/modified in this PR contain relevant docstrings.
