### PR TITLE
fix: allow completed orders to have a charge in validations of charges data layer 

### DIFF
--- a/app/api/data_layers/ChargesLayer.py
+++ b/app/api/data_layers/ChargesLayer.py
@@ -27,9 +27,9 @@ class ChargesLayer(BaseDataLayer):
         if not order:
             raise ObjectNotFound({'parameter': 'order_identifier'},
                                  "Order with identifier: {} not found".format(view_kwargs['order_identifier']))
-        elif order.status == 'cancelled' or order.status == 'expired' or order.status == 'completed':
+        elif order.status == 'cancelled' or order.status == 'expired':
             raise ConflictException({'parameter': 'id'},
-                                    "You cannot charge payments on a cancelled, expired or completed order")
+                                    "You cannot charge payments on a cancelled or expired order")
         elif (not order.amount) or order.amount == 0:
             raise ConflictException({'parameter': 'id'},
                                     "You cannot charge payments on a free order")


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6283 

Upon successful payment, order is already completed. hence has the status of completed.

