### PR TITLE
[WIP] fix: displays from_name specified in admin settings in email sent

### DIFF
--- a/app/api/helpers/mail.py
+++ b/app/api/helpers/mail.py
@@ -42,10 +42,7 @@ def send_email(to, action, subject, html, attachments=None):
     if not string_empty(to):
         email_service = get_settings()['email_service']
         email_from_name = get_settings()['email_from_name']
-        if email_service == 'smtp':
-            email_from = email_from_name + '<' + get_settings()['email_from'] + '>'
-        else:
-            email_from = get_settings()['email_from']
+        email_from = email_from_name + '<' + get_settings()['email_from'] + '>'
         payload = {
             'to': to,
             'from': email_from,


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6306 

#### Short description of what this resolves:
On eventyay in the email settings the from name specified is "Eventyay". However the emails received do not show the name. They only show the from email.

#### Changes proposed in this pull request:
- Now the email displays - `eventyay<info@eventyay.com>` 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
