### PR TITLE
fix: check for paid orders to show billing info

### DIFF
--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -68,7 +68,7 @@ def check_billing_info(data):
         raise UnprocessableEntity({'pointer': '/data/attributes/is_billing_enabled'},
                                   "Billing information is mandatory for paid orders")
     if data.get('is_billing_enabled') and not (data.get('company') and data.get('address') and data.get('city') and
-                                               data.get('zip') and data.get('country')):
+                                               data.get('zipcode') and data.get('country')):
         raise UnprocessableEntity({'pointer': '/data/attributes/is_billing_enabled'},
                                   "Billing information incomplete")
 
@@ -106,7 +106,8 @@ class OrdersListPost(ResourceList):
         :param view_kwargs:
         :return:
         """
-        check_billing_info(data)
+        if data.get('amount') > 0 and not data.get('is_billing_enabled'):
+            data['is_billing_enabled'] = True
 
         free_ticket_quantity = 0
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6309, fossasia/open-event-frontend#3367

#### Changes proposed in this pull request:

- Edit validation check
- Set `is_billing_enabled` to true for paid orders

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.
