### PR TITLE
fix: use from email name for sendgrid emails

### DIFF
--- a/app/api/helpers/tasks.py
+++ b/app/api/helpers/tasks.py
@@ -10,7 +10,7 @@ from marrow.mailer import Mailer, Message
 from app import get_settings
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import (
-    Mail, Attachment, FileContent, FileName,
+    Mail, Attachment, FileContent, FileName, From,
     FileType, Disposition)
 
 from app import make_celery
@@ -55,7 +55,7 @@ celery = make_celery()
 @celery.task(name='send.email.post.sendgrid')
 def send_email_task_sendgrid(payload, headers, smtp_config):
     try:
-        message = Mail(from_email=payload['from'],
+        message = Mail(from_email=From(payload['from'], payload['fromname']),
                        to_emails=payload['to'],
                        subject=payload['subject'],
                        html_content=payload["html"])


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6306 

Ensures from email name is used while sending out mails via sendgrid. Tested as working.