### PR TITLE
fix: order updation without 'amount' key works

### DIFF
--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -64,7 +64,7 @@ def is_payment_valid(order, mode):
 
 
 def check_billing_info(data):
-    if data.get('amount') > 0 and not data.get('is_billing_enabled'):
+    if data.get('amount') and data.get('amount') > 0 and not data.get('is_billing_enabled'):
         raise UnprocessableEntity({'pointer': '/data/attributes/is_billing_enabled'},
                                   "Billing information is mandatory for paid orders")
     if data.get('is_billing_enabled') and not (data.get('company') and data.get('address') and data.get('city') and
@@ -311,7 +311,8 @@ class OrderDetail(ResourceDetail):
         :param view_kwargs:
         :return:
         """
-        check_billing_info(data)
+        if data.get('amount') or data.get('is_billing_enabled'):
+            check_billing_info(data)
         if (not has_access('is_coorganizer', event_id=order.event_id)) and (not current_user.id == order.user_id):
             raise ForbiddenException({'pointer': ''}, "Access Forbidden")
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes https://github.com/fossasia/open-event-attendee-android/issues/2262

#### Short description of what this resolves:
Orders which were updated without `amount` key produces error

#### Changes proposed in this pull request:
- call `check_billing_info` only if `amount` key is there

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
