### PR TITLE
fix: Typo in the notification invitation message

### DIFF
--- a/app/api/helpers/system_notifications.py
+++ b/app/api/helpers/system_notifications.py
@@ -392,7 +392,7 @@ NOTIFS = {
     },
     EVENT_ROLE: {
         'title': u'Invitation to be {role_name} at {event_name}',
-        'message': u"You've been invited to be one of the <strong>{role_name}</strong>s" +
+        'message': u"You've been invited to be one of the <strong>{role_name}s</strong>" +
                    u" at <strong>{event_name}</strong>.",
         'recipient': 'User',
     },

--- a/app/api/helpers/system_notifications.py
+++ b/app/api/helpers/system_notifications.py
@@ -392,7 +392,7 @@ NOTIFS = {
     },
     EVENT_ROLE: {
         'title': u'Invitation to be {role_name} at {event_name}',
-        'message': u"You've been invited to be a <strong>{role_name}</strong>" +
+        'message': u"You've been invited to be one of the <strong>{role_name}</strong>s" +
                    u" at <strong>{event_name}</strong>.",
         'recipient': 'User',
     },


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5872 

#### Short description of what this resolves:

Resolves display of 'a' in event notifications

#### Changes proposed in this pull request:

Changes notification message such that event role beginning with vowel or consonant does not matter

-
-
-

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
