### PR TITLE
feat: API to fetch total order amount by passing tickets and discount code

### DIFF
--- a/app/api/helpers/order.py
+++ b/app/api/helpers/order.py
@@ -11,6 +11,7 @@ from app.api.helpers.files import create_save_pdf
 from app.api.helpers.storage import UPLOAD_PATHS
 from app.models import db
 from app.models.ticket import Ticket
+from app.models.ticket_fee import TicketFees
 from app.models.ticket_holder import TicketHolder
 from app.models.order import OrderTicket
 
@@ -131,3 +132,86 @@ def create_onsite_attendees_for_order(data):
 
     # delete from the data.
     del data['on_site_tickets']
+
+
+def calculate_order_amount(tickets, discount_code):
+    event = tax = tax_included = fees = None
+    total_amount = total_tax = total_discount = 0.0
+    ticket_list = []
+    for ticket_info in tickets:
+        tax_amount = tax_percent = 0.0
+        tax_data = {}
+        discount_amount = discount_percent = 0.0
+        discount_data = {}
+        sub_total = ticket_fee = 0.0
+
+        ticket_identifier = ticket_info['id']
+        quantity = ticket_info['quantity']
+        ticket = safe_query_without_soft_deleted_entries(db, Ticket, 'id', ticket_identifier, 'id')
+        if not event:
+            event = ticket.event
+            fees = TicketFees.query.filter_by(currency=event.payment_currency).first()
+        elif ticket.event.id != event.id:
+            raise UnprocessableEntity({'source': 'data/tickets'}, "Invalid Ticket")
+
+        if not tax and event.tax:
+            tax = event.tax
+            tax_included = tax.is_tax_included_in_price
+
+        if ticket.type == 'donation':
+            price = ticket_info.get('price')
+            if not price or price > ticket.max_price or price < ticket.min_price:
+                raise UnprocessableEntity({'source': 'data/tickets'}, "Price for donation ticket invalid")
+        else:
+            price = ticket.price
+
+        if discount_code:
+            for code in ticket.discount_codes:
+                if discount_code.id == code.id:
+                    if code.type == 'amount':
+                        discount_amount = code.value
+                        discount_percent = (discount_amount / price) * 100
+                    else:
+                        discount_amount = (price * code.value)/100
+                        discount_percent = code.value
+                    discount_data = {
+                        'code': discount_code.code,
+                        'percent': round(discount_percent, 2),
+                        'amount': round(discount_amount, 2)
+                    }
+
+        if tax:
+            if not tax_included:
+                tax_amount = ((price - discount_amount) * tax.rate)/100
+                tax_percent = tax.rate
+            else:
+                tax_amount = ((price - discount_amount) * tax.rate)/(100 + tax.rate)
+                tax_percent = tax.rate
+            tax_data = {
+                'percent': round(tax_percent, 2),
+                'amount': round(tax_amount, 2),
+            }
+
+        total_tax = total_tax + tax_amount * quantity
+        total_discount = total_discount + discount_amount*quantity
+        if fees and not ticket.is_fee_absorbed:
+            ticket_fee = fees.service_fee * (price * quantity) / 100
+            if ticket_fee > fees.maximum_fee:
+                ticket_fee = fees.maximum_fee
+        if tax_included:
+            sub_total = ticket_fee + (price - discount_amount)*quantity
+        else:
+            sub_total = ticket_fee + (price + tax_amount - discount_amount)*quantity
+        total_amount = total_amount + sub_total
+        ticket_list.append({
+            'id': ticket.id,
+            'name': ticket.name,
+            'price': price,
+            'quantity': quantity,
+            'discount': discount_data,
+            'tax': tax_data,
+            'ticket_fee': round(ticket_fee, 2),
+            'sub_total': round(sub_total, 2)
+        })
+    return dict(tax_included=tax_included, total_amount=round(total_amount, 2), total_tax=round(total_tax, 2),
+                total_discount=round(total_discount, 2), tickets=ticket_list)

--- a/app/api/helpers/ticketing.py
+++ b/app/api/helpers/ticketing.py
@@ -22,15 +22,20 @@ class TicketingManager(object):
         return 10
 
     @staticmethod
-    def match_discount_quantity(discount_code, ticket_holders=None):
+    def match_discount_quantity(discount_code, tickets=None, ticket_holders=None):
         qty = 0
         ticket_ids = [ticket.id for ticket in discount_code.tickets]
         old_holders = get_count(TicketHolder.query.filter(TicketHolder.ticket_id.in_(ticket_ids))
                                 .join(Order).filter(Order.status.in_(['completed', 'placed'])))
-        for holder in ticket_holders:
-            ticket_holder = TicketHolder.query.filter_by(id=holder).one()
-            if ticket_holder.ticket.id in ticket_ids:
-                qty += 1
+        if ticket_holders:
+            for holder in ticket_holders:
+                ticket_holder = TicketHolder.query.filter_by(id=holder).one()
+                if ticket_holder.ticket.id in ticket_ids:
+                    qty += 1
+        elif tickets:
+            for ticket in tickets:
+                if int(ticket['id']) in ticket_ids:
+                    qty += ticket['quantity']
         if (qty + old_holders) <= discount_code.tickets_number and \
             discount_code.min_quantity <= qty <= discount_code.max_quantity:
             return True

--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -158,7 +158,7 @@ class OrdersListPost(ResourceList):
                 valid_till = discount_code.valid_till
                 if not (valid_from <= now <= valid_till):
                     raise UnprocessableEntity({'source': 'discount_code_id'}, "Inactive Discount Code")
-                if not TicketingManager.match_discount_quantity(discount_code, data['ticket_holders']):
+                if not TicketingManager.match_discount_quantity(discount_code, None, data['ticket_holders']):
                     raise UnprocessableEntity({'source': 'discount_code_id'}, 'Discount Usage Exceeded')
             if discount_code.event.id != int(data['event']):
                 raise UnprocessableEntity({'source': 'discount_code_id'}, "Invalid Discount Code")


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6323

#### Changes proposed in this pull request:
- Adds an API to fetch total order amount by posting tickets, their amount, event and discount code
**Payload**
```
           {
                "tickets": [
                	{"id": "32", "quantity": 2, "price": 100},
                	{"id": "31", "quantity": 3}
                ],
                "discount-code": "16"
            }
```

**Response**
```
{
    "tax_included": false,
    "tickets": [
        {
            "discount": {},
            "id": 32,
            "name": "donation",
            "price": 100,
            "quantity": 1,
            "sub_total": 110.5,
            "tax": {
                "amount": 10.5,
                "percent": 10.5
            },
            "ticket_fee": 0
        },
        {
            "discount": {
                "amount": 15,
                "code": "s1",
                "percent": 17.65
            },
            "id": 31,
            "name": "paid",
            "price": 85,
            "quantity": 1,
            "sub_total": 153.85,
            "tax": {
                "amount": 7.35,
                "percent": 10.5
            },
            "ticket_fee": 76.5
        }
    ],
    "total_amount": 264.35,
    "total_discount": 15,
    "total_tax": 17.85
}
```

#### Checklist

Ensure it works:

- [x] with event including tax
- [x] excluding tax, 
- [x] with discount code, 
- [x] without discount code, 
- [x] with donation ticket price
- [x] without donation ticket price
