### PR TITLE
feat: Support for non-attachment mails

### DIFF
--- a/app/api/helpers/tasks.py
+++ b/app/api/helpers/tasks.py
@@ -52,6 +52,14 @@ import base64
 celery = make_celery()
 
 
+def empty_attachments_send(mail_client, message):
+    """
+    Empty attachments and send mail
+    """
+    logging.warning("Attachments could not be sent. Sending confirmation mail without attachments...")
+    message.attachments = []
+    mail_client.send(message)
+
 @celery.task(name='send.email.post.sendgrid')
 def send_email_task_sendgrid(payload, headers, smtp_config):
     try:
@@ -79,6 +87,8 @@ def send_email_task_sendgrid(payload, headers, smtp_config):
         if e.code == 429:
             logging.warning("Sendgrid quota has exceeded")
             send_email_task_smtp.delay(payload=payload, headers=None, smtp_config=smtp_config)
+        elif e.code == 554:
+            empty_attachments_send(sendgrid_client, message)
         else:
             logging.exception("The following error has occurred with sendgrid-{}".format(str(e)))
 
@@ -96,17 +106,21 @@ def send_email_task_smtp(payload, smtp_config, headers=None):
             }
         }
 
-    mailer = Mailer(mailer_config)
-    mailer.start()
-    message = Message(author=payload['from'], to=payload['to'])
-    message.subject = payload['subject']
-    message.plain = strip_tags(payload['html'])
-    message.rich = payload['html']
-    if payload['attachments'] is not None:
-        for attachment in payload['attachments']:
-            message.attach(name=attachment)
-    mailer.send(message)
-    logging.info('Message sent via SMTP')
+    try:
+        mailer = Mailer(mailer_config)
+        mailer.start()
+        message = Message(author=payload['from'], to=payload['to'])
+        message.subject = payload['subject']
+        message.plain = strip_tags(payload['html'])
+        message.rich = payload['html']
+        if payload['attachments'] is not None:
+            for attachment in payload['attachments']:
+                message.attach(name=attachment)
+        mailer.send(message)
+        logging.info('Message sent via SMTP')
+    except urllib.error.HTTPError as e:
+        if e.code == 554:
+            empty_attachments_send(mailer, message)
     mailer.stop()
 
 @celery.task(base=RequestContextTask, name='resize.event.images', bind=True)


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6047 

#### Short description of what this resolves:
 This PR aims to enable the mail task to send emails even when attachments are blocked by the mail server.

#### Changes proposed in this pull request:

- Added logic to erase the mail attachments when gmail (or) other mail providers don't allow them.
