### PR TITLE
fix: Fix the url for all the exports

### DIFF
--- a/app/api/helpers/storage.py
+++ b/app/api/helpers/storage.py
@@ -178,7 +178,7 @@ def upload_local(uploaded_file, key, upload_dir='static/media/', **kwargs):
     file_relative_path = '/' + file_relative_path
     if get_settings()['static_domain']:
         return get_settings()['static_domain'] + \
-               file_relative_path.replace('/static', '')
+               file_relative_path
 
     return create_url(request.url, file_relative_path)
 

--- a/tests/all/integration/api/helpers/test_storage.py
+++ b/tests/all/integration/api/helpers/test_storage.py
@@ -19,7 +19,7 @@ class TestStorage(OpenEventTestCase):
     @patch('app.api.helpers.storage.get_settings', return_value={'static_domain': 'https://next.eventyay.com'})
     @patch('app.api.helpers.storage.UploadedFile')
     def test_upload_local(self, uploadedfile_object, settings, generated_hash, uploadlocal):
-        expected_response = 'https://next.eventyay.com/media/upload_key/hash/test.pdf'
+        expected_response = 'https://next.eventyay.com/static/media/upload_key/hash/test.pdf'
         uploadedfile_object.filename = 'test.pdf'
 
         with app.test_request_context():


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6213 
Fixes #6409 
Fixes #6214 
Fixes #6392 
#### Short description of what this resolves:
Removes the unnecessary replacement in returned URL of the storage helper.

@iamareebjamal This might just fix the images on localhost issue too, as previously static domain wasn't configured now it is.