### PR TITLE
fix: Ensure that event identifier is a string

### DIFF
--- a/app/models/event.py
+++ b/app/models/event.py
@@ -29,10 +29,15 @@ from app.models.ticket_holder import TicketHolder
 def get_new_event_identifier(length=8):
     identifier = str(binascii.b2a_hex(os.urandom(int(length / 2))), 'utf-8')
     count = get_count(Event.query.filter_by(identifier=identifier))
-    if count == 0:
-        return identifier
-    else:
+    try:
+        int(identifier)
+    except ValueError:
         return get_new_event_identifier(length)
+    else:
+        if count == 0:
+            return identifier
+        else:
+            return get_new_event_identifier(length)
 
 
 class Event(SoftDeletionModel):


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6423 

#### Short description of what this resolves:
Event identifier in case of some event happened to be an integer and hence it failed to open.

#### Changes proposed in this pull request:
- Ensure that identifier is always a string