### PR TITLE
DOC Correct API docs of update orders

### DIFF
--- a/docs/api/blueprint/order/orders.apib
+++ b/docs/api/blueprint/order/orders.apib
@@ -329,7 +329,7 @@ Update a single custom form with `id`.
                   "order-notes": "example"
                 },
                 "type": "order",
-                "id": "ab25a170-f36d-4dd6-b99c-9c202e693afc"
+                "id": "1"
               }
             }
 


### PR DESCRIPTION
The `PATCH` request for orders API docs showed identifier instead
of the id as the value of `id` in body of the request,
which actually shows an error when used.

Changed value to valid `id`.

closes #6451
