### PR TITLE
[WIP]Refactor: Udes data classes in event modules to remove redundant code.

### DIFF
--- a/app/models/event.py
+++ b/app/models/event.py
@@ -2,6 +2,7 @@ import binascii
 import os
 from datetime import datetime
 
+from dataclasses import dataclass
 import flask_login as login
 import pytz
 from flask import current_app
@@ -35,37 +36,38 @@ def get_new_event_identifier(length=8):
         return get_new_event_identifier(length)
 
 
+@dataclass(init=True, repr=True, unsafe_hash=True)
 class Event(SoftDeletionModel):
     """Event object table"""
     __tablename__ = 'events'
     __versioned__ = {
         'exclude': ['schedule_published_on', 'created_at']
     }
-    id = db.Column(db.Integer, primary_key=True)
-    identifier = db.Column(db.String)
-    name = db.Column(db.String, nullable=False)
-    external_event_url = db.Column(db.String)
-    logo_url = db.Column(db.String)
-    starts_at = db.Column(db.DateTime(timezone=True), nullable=False)
-    ends_at = db.Column(db.DateTime(timezone=True), nullable=False)
-    timezone = db.Column(db.String, nullable=False, default="UTC")
-    is_event_online = db.Column(db.Boolean, default=False)
-    latitude = db.Column(db.Float)
-    longitude = db.Column(db.Float)
-    location_name = db.Column(db.String)
-    searchable_location_name = db.Column(db.String)
-    is_featured = db.Column(db.Boolean, default=False, nullable=False)
-    description = db.Column(db.Text)
-    original_image_url = db.Column(db.String)
-    thumbnail_image_url = db.Column(db.String)
-    large_image_url = db.Column(db.String)
-    show_remaining_tickets = db.Column(db.Boolean, default=False, nullable=False)
-    icon_image_url = db.Column(db.String)
-    owner_name = db.Column(db.String)
-    is_map_shown = db.Column(db.Boolean)
-    has_owner_info = db.Column(db.Boolean)
-    owner_description = db.Column(db.String)
-    is_sessions_speakers_enabled = db.Column(db.Boolean, default=False)
+    id: int = db.Column(db.Integer, primary_key=True)
+    identifier: str = db.Column(db.String)
+    name: str = db.Column(db.String, nullable=False)
+    external_event_url: str = db.Column(db.String)
+    logo_url: str = db.Column(db.String)
+    starts_at: datetime = db.Column(db.DateTime(timezone=True), nullable=False)
+    ends_at: datetime = db.Column(db.DateTime(timezone=True), nullable=False)
+    timezone: str = db.Column(db.String, nullable=False, default="UTC")
+    is_event_online: bool = db.Column(db.Boolean, default=False)
+    latitude: float = db.Column(db.Float)
+    longitude: float = db.Column(db.Float)
+    location_name: str = db.Column(db.String)
+    searchable_location_name: str = db.Column(db.String)
+    is_featured: bool = db.Column(db.Boolean, default=False, nullable=False)
+    description: str = db.Column(db.Text)
+    original_image_url: str = db.Column(db.String)
+    thumbnail_image_url: str = db.Column(db.String)
+    large_image_url: str = db.Column(db.String)
+    show_remaining_tickets: bool = db.Column(db.Boolean, default=False, nullable=False)
+    icon_image_url: str = db.Column(db.String)
+    owner_name: str = db.Column(db.String)
+    is_map_shown: bool = db.Column(db.Boolean)
+    has_owner_info: bool = db.Column(db.Boolean)
+    owner_description: str = db.Column(db.String)
+    is_sessions_speakers_enabled: bool = db.Column(db.Boolean, default=False)
     track = db.relationship('Track', backref="event")
     microlocation = db.relationship('Microlocation', backref="event")
     session = db.relationship('Session', backref="event")
@@ -79,45 +81,45 @@ class Event(SoftDeletionModel):
     faqs = db.relationship('Faq', backref="event")
     feedbacks = db.relationship('Feedback', backref="event")
     attendees = db.relationship('TicketHolder', backref="event")
-    privacy = db.Column(db.String, default="public")
-    state = db.Column(db.String, default="Draft")
-    event_type_id = db.Column(db.Integer, db.ForeignKey('event_types.id', ondelete='CASCADE'))
-    event_topic_id = db.Column(db.Integer, db.ForeignKey('event_topics.id', ondelete='CASCADE'))
-    event_sub_topic_id = db.Column(db.Integer, db.ForeignKey(
+    privacy: str = db.Column(db.String, default="public")
+    state: str = db.Column(db.String, default="Draft")
+    event_type_id: int = db.Column(db.Integer, db.ForeignKey('event_types.id', ondelete='CASCADE'))
+    event_topic_id: int = db.Column(db.Integer, db.ForeignKey('event_topics.id', ondelete='CASCADE'))
+    event_sub_topic_id: int = db.Column(db.Integer, db.ForeignKey(
         'event_sub_topics.id', ondelete='CASCADE'))
-    events_orga_id = db.Column(db.Integer, db.ForeignKey(
+    events_orga_id: int = db.Column(db.Integer, db.ForeignKey(
         'events_orga.id', ondelete='CASCADE'))
-    ticket_url = db.Column(db.String)
+    ticket_url: str = db.Column(db.String)
     db.UniqueConstraint('track.name')
-    code_of_conduct = db.Column(db.String)
-    schedule_published_on = db.Column(db.DateTime(timezone=True))
-    is_ticketing_enabled = db.Column(db.Boolean, default=False)
-    is_donation_enabled = db.Column(db.Boolean, default=False)
-    is_ticket_form_enabled = db.Column(db.Boolean, default=True, nullable=False)
-    payment_country = db.Column(db.String)
-    payment_currency = db.Column(db.String)
-    paypal_email = db.Column(db.String)
-    is_tax_enabled = db.Column(db.Boolean, default=False)
-    is_billing_info_mandatory = db.Column(db.Boolean, default=False)
-    can_pay_by_paypal = db.Column(db.Boolean, default=False, nullable=False)
-    can_pay_by_stripe = db.Column(db.Boolean, default=False, nullable=False)
-    can_pay_by_cheque = db.Column(db.Boolean, default=False, nullable=False)
-    can_pay_by_bank = db.Column(db.Boolean, default=False, nullable=False)
-    can_pay_onsite = db.Column(db.Boolean, default=False, nullable=False)
-    can_pay_by_omise = db.Column(db.Boolean, default=False, nullable=False)
-    can_pay_by_alipay = db.Column(db.Boolean, default=False, nullable=False)
-    can_pay_by_paytm = db.Column(db.Boolean, default=False, nullable=False)
-    cheque_details = db.Column(db.String)
-    bank_details = db.Column(db.String)
-    onsite_details = db.Column(db.String)
-    created_at = db.Column(db.DateTime(timezone=True))
-    pentabarf_url = db.Column(db.String)
-    ical_url = db.Column(db.String)
-    xcal_url = db.Column(db.String)
-    is_sponsors_enabled = db.Column(db.Boolean, default=False)
-    refund_policy = db.Column(db.String, default='All sales are final. No refunds shall be issued in any case.')
-    is_stripe_linked = db.Column(db.Boolean, default=False)
-    discount_code_id = db.Column(db.Integer, db.ForeignKey(
+    code_of_conduct: str = db.Column(db.String)
+    schedule_published_on: datetime = db.Column(db.DateTime(timezone=True))
+    is_ticketing_enabled: bool = db.Column(db.Boolean, default=False)
+    is_donation_enabled: bool = db.Column(db.Boolean, default=False)
+    is_ticket_form_enabled: bool = db.Column(db.Boolean, default=True, nullable=False)
+    payment_country: str = db.Column(db.String)
+    payment_currency: str = db.Column(db.String)
+    paypal_email: str = db.Column(db.String)
+    is_tax_enabled: bool = db.Column(db.Boolean, default=False)
+    is_billing_info_mandatory: bool = db.Column(db.Boolean, default=False)
+    can_pay_by_paypal: bool = db.Column(db.Boolean, default=False, nullable=False)
+    can_pay_by_stripe: bool = db.Column(db.Boolean, default=False, nullable=False)
+    can_pay_by_cheque: bool = db.Column(db.Boolean, default=False, nullable=False)
+    can_pay_by_bank: bool = db.Column(db.Boolean, default=False, nullable=False)
+    can_pay_onsite: bool = db.Column(db.Boolean, default=False, nullable=False)
+    can_pay_by_omise: bool = db.Column(db.Boolean, default=False, nullable=False)
+    can_pay_by_alipay: bool = db.Column(db.Boolean, default=False, nullable=False)
+    can_pay_by_paytm: bool = db.Column(db.Boolean, default=False, nullable=False)
+    cheque_details: str = db.Column(db.String)
+    bank_details: str = db.Column(db.String)
+    onsite_details: str = db.Column(db.String)
+    created_at: datetime = db.Column(db.DateTime(timezone=True))
+    pentabarf_url: str = db.Column(db.String)
+    ical_url: str = db.Column(db.String)
+    xcal_url: str = db.Column(db.String)
+    is_sponsors_enabled: bool = db.Column(db.Boolean, default=False)
+    refund_policy: str = db.Column(db.String, default='All sales are final. No refunds shall be issued in any case.')
+    is_stripe_linked: bool = db.Column(db.Boolean, default=False)
+    discount_code_id: int = db.Column(db.Integer, db.ForeignKey(
         'discount_codes.id', ondelete='CASCADE'))
     discount_code = db.relationship('DiscountCode', backref='events', foreign_keys=[discount_code_id])
     event_type = db.relationship('EventType', backref='event', foreign_keys=[event_type_id])
@@ -178,146 +180,6 @@ class Event(SoftDeletionModel):
                             primaryjoin='UsersEventsRoles.event_id == Event.id',
                             secondaryjoin='User.id == UsersEventsRoles.user_id',
                             backref='events')
-
-    def __init__(self,
-                 name=None,
-                 logo_url=None,
-                 starts_at=None,
-                 ends_at=None,
-                 timezone='UTC',
-                 is_event_online=False,
-                 latitude=None,
-                 longitude=None,
-                 location_name=None,
-                 description=None,
-                 external_event_url=None,
-                 original_image_url=None,
-                 thumbnail_image_url=None,
-                 large_image_url=None,
-                 icon_image_url=None,
-                 owner_name=None,
-                 owner_description=None,
-                 state=None,
-                 event_type_id=None,
-                 privacy=None,
-                 event_topic_id=None,
-                 event_sub_topic_id=None,
-                 events_orga_id=None,
-                 ticket_url=None,
-                 copyright=None,
-                 code_of_conduct=None,
-                 schedule_published_on=None,
-                 is_sessions_speakers_enabled=False,
-                 show_remaining_tickets=False,
-                 is_ticket_form_enabled=True,
-                 is_donation_enabled=False,
-                 is_map_shown=False,
-                 has_owner_info=False,
-                 searchable_location_name=None,
-                 is_ticketing_enabled=None,
-                 deleted_at=None,
-                 payment_country=None,
-                 payment_currency=None,
-                 paypal_email=None,
-                 speakers_call=None,
-                 can_pay_by_paypal=False,
-                 can_pay_by_stripe=False,
-                 can_pay_by_cheque=False,
-                 can_pay_by_omise=False,
-                 can_pay_by_alipay=False,
-                 can_pay_by_paytm=False,
-                 identifier=None,
-                 can_pay_by_bank=False,
-                 is_featured=False,
-                 can_pay_onsite=False,
-                 cheque_details=None,
-                 bank_details=None,
-                 pentabarf_url=None,
-                 ical_url=None,
-                 xcal_url=None,
-                 discount_code_id=None,
-                 onsite_details=None,
-                 is_tax_enabled=None,
-                 is_billing_info_mandatory=False,
-                 is_sponsors_enabled=None,
-                 stripe_authorization=None,
-                 tax=None,
-                 refund_policy='All sales are final. No refunds shall be issued in any case.',
-                 is_stripe_linked=False):
-
-        self.name = name
-        self.logo_url = logo_url
-        self.starts_at = starts_at
-        self.ends_at = ends_at
-        self.timezone = timezone
-        self.is_event_online = is_event_online
-        self.latitude = latitude
-        self.longitude = longitude
-        self.location_name = location_name
-        self.description = clean_up_string(description)
-        self.external_event_url = external_event_url
-        self.original_image_url = original_image_url
-        self.original_image_url = self.set_default_event_image(event_topic_id) if original_image_url is None \
-            else original_image_url
-        self.thumbnail_image_url = thumbnail_image_url
-        self.large_image_url = large_image_url
-        self.icon_image_url = icon_image_url
-        self.owner_name = owner_name
-        self.owner_description = clean_up_string(owner_description)
-        self.state = state
-        self.is_map_shown = is_map_shown
-        self.has_owner_info = has_owner_info
-        self.privacy = privacy
-        self.event_type_id = event_type_id
-        self.event_topic_id = event_topic_id
-        self.show_remaining_tickets = show_remaining_tickets
-        self.copyright = copyright
-        self.event_sub_topic_id = event_sub_topic_id
-        self.events_orga_id = events_orga_id
-        self.ticket_url = ticket_url
-        self.code_of_conduct = code_of_conduct
-        self.schedule_published_on = schedule_published_on
-        self.is_sessions_speakers_enabled = is_sessions_speakers_enabled
-        self.searchable_location_name = searchable_location_name
-        self.is_ticketing_enabled = is_ticketing_enabled
-        self.deleted_at = deleted_at
-        self.payment_country = payment_country
-        self.payment_currency = payment_currency
-        self.paypal_email = paypal_email
-        self.speakers_call = speakers_call
-        self.can_pay_by_paypal = can_pay_by_paypal
-        self.can_pay_by_stripe = can_pay_by_stripe
-        self.can_pay_by_cheque = can_pay_by_cheque
-        self.can_pay_by_bank = can_pay_by_bank
-        self.can_pay_onsite = can_pay_onsite
-        self.can_pay_by_omise = can_pay_by_omise
-        self.can_pay_by_alipay = can_pay_by_alipay
-        self.can_pay_by_paytm = can_pay_by_paytm
-        self.is_donation_enabled = is_donation_enabled
-        self.is_featured = is_featured
-        self.is_ticket_form_enabled = is_ticket_form_enabled
-        self.identifier = get_new_event_identifier()
-        self.cheque_details = cheque_details
-        self.bank_details = bank_details
-        self.pentabarf_url = pentabarf_url
-        self.ical_url = ical_url
-        self.xcal_url = xcal_url
-        self.onsite_details = onsite_details
-        self.discount_code_id = discount_code_id
-        self.created_at = datetime.now(pytz.utc)
-        self.is_tax_enabled = is_tax_enabled
-        self.is_billing_info_mandatory = is_billing_info_mandatory
-        self.is_sponsors_enabled = is_sponsors_enabled
-        self.stripe_authorization = stripe_authorization
-        self.tax = tax
-        self.refund_policy = refund_policy
-        self.is_stripe_linked = is_stripe_linked
-
-    def __repr__(self):
-        return '<Event %r>' % self.name
-
-    def __str__(self):
-        return self.__repr__()
 
     def __setattr__(self, name, value):
         if name == 'owner_description' or name == 'description' or name == 'code_of_conduct':

--- a/app/models/event_copyright.py
+++ b/app/models/event_copyright.py
@@ -1,49 +1,27 @@
 from sqlalchemy.orm import backref
 
+from dataclasses import dataclass
 from app.models import db
 from app.models.base import SoftDeletionModel
 
 
+@dataclass(init=True, repr=True, unsafe_hash=True)
 class EventCopyright(SoftDeletionModel):
     """
     Copyright Information about an event.
     """
     __tablename__ = 'event_copyrights'
 
-    id = db.Column(db.Integer, primary_key=True)
-    holder = db.Column(db.String)
-    holder_url = db.Column(db.String)
-    licence = db.Column(db.String, nullable=False)
-    licence_url = db.Column(db.String)
-    year = db.Column(db.Integer)
-    logo = db.Column(db.String)
+    id: int = db.Column(db.Integer, primary_key=True)
+    holder: str = db.Column(db.String)
+    holder_url: str = db.Column(db.String)
+    licence: str = db.Column(db.String, nullable=False)
+    licence_url: str = db.Column(db.String)
+    year: int = db.Column(db.Integer)
+    logo: str = db.Column(db.String)
 
-    event_id = db.Column(db.Integer, db.ForeignKey('events.id', ondelete='CASCADE'))
+    event_id: int = db.Column(db.Integer, db.ForeignKey('events.id', ondelete='CASCADE'))
     event = db.relationship('Event', backref=backref('copyright', uselist=False))
-
-    def __init__(self,
-                 holder=None,
-                 holder_url=None,
-                 licence=None,
-                 licence_url=None,
-                 year=None,
-                 logo=None,
-                 event_id=None,
-                 deleted_at=None):
-        self.holder = holder
-        self.holder_url = holder_url
-        self.licence = licence
-        self.licence_url = licence_url
-        self.year = year
-        self.logo = logo
-        self.event_id = event_id
-        self.deleted_at = deleted_at
-
-    def __repr__(self):
-        return '<Copyright %r>' % self.holder
-
-    def __str__(self):
-        return self.__repr__()
 
     @property
     def serialize(self):

--- a/app/models/event_invoice.py
+++ b/app/models/event_invoice.py
@@ -2,6 +2,7 @@ import time
 import uuid
 from datetime import datetime
 
+from dataclasses import dataclass
 from app.api.helpers.db import get_count
 from app.models import db
 from app.models.base import SoftDeletionModel
@@ -16,38 +17,39 @@ def get_new_identifier():
         return get_new_identifier()
 
 
+@dataclass(init=True, repr=True, unsafe_hash=True)
 class EventInvoice(SoftDeletionModel):
     """
     Stripe authorization information for an event.
     """
     __tablename__ = 'event_invoices'
 
-    id = db.Column(db.Integer, primary_key=True)
-    identifier = db.Column(db.String, unique=True)
-    amount = db.Column(db.Float)
-    address = db.Column(db.String)
-    city = db.Column(db.String)
-    state = db.Column(db.String)
-    country = db.Column(db.String)
-    zipcode = db.Column(db.String)
+    id: int = db.Column(db.Integer, primary_key=True)
+    identifier: str = db.Column(db.String, unique=True)
+    amount: float = db.Column(db.Float)
+    address: str = db.Column(db.String)
+    city: str = db.Column(db.String)
+    state: str = db.Column(db.String)
+    country: str = db.Column(db.String)
+    zipcode: str = db.Column(db.String)
 
-    user_id = db.Column(db.Integer, db.ForeignKey('users.id', ondelete='SET NULL'))
-    event_id = db.Column(db.Integer, db.ForeignKey('events.id', ondelete='SET NULL'))
-    order_id = db.Column(db.Integer, db.ForeignKey('orders.id', ondelete='SET NULL'))
+    user_id: int = db.Column(db.Integer, db.ForeignKey('users.id', ondelete='SET NULL'))
+    event_id: int = db.Column(db.Integer, db.ForeignKey('events.id', ondelete='SET NULL'))
+    order_id: int = db.Column(db.Integer, db.ForeignKey('orders.id', ondelete='SET NULL'))
 
-    created_at = db.Column(db.DateTime(timezone=True))
-    completed_at = db.Column(db.DateTime(timezone=True), nullable=True, default=None)
-    transaction_id = db.Column(db.String)
-    paid_via = db.Column(db.String)
-    payment_mode = db.Column(db.String)
-    brand = db.Column(db.String)
-    exp_month = db.Column(db.Integer)
-    exp_year = db.Column(db.Integer)
-    last4 = db.Column(db.String)
-    stripe_token = db.Column(db.String)
-    paypal_token = db.Column(db.String)
-    status = db.Column(db.String)
-    invoice_pdf_url = db.Column(db.String)
+    created_at: datetime = db.Column(db.DateTime(timezone=True))
+    completed_at: datetime = db.Column(db.DateTime(timezone=True), nullable=True, default=None)
+    transaction_id: str = db.Column(db.String)
+    paid_via: str = db.Column(db.String)
+    payment_mode: str = db.Column(db.String)
+    brand: str = db.Column(db.String)
+    exp_month: int = db.Column(db.Integer)
+    exp_year: int = db.Column(db.Integer)
+    last4: str = db.Column(db.String)
+    stripe_token: str = db.Column(db.String)
+    paypal_token: str = db.Column(db.String)
+    status: str = db.Column(db.String)
+    invoice_pdf_url: str = db.Column(db.String)
 
     event = db.relationship('Event', backref='invoices')
 
@@ -55,62 +57,9 @@ class EventInvoice(SoftDeletionModel):
 
     user = db.relationship('User', backref='invoices')
 
-    discount_code_id = db.Column(db.Integer, db.ForeignKey('discount_codes.id', ondelete='SET NULL'),
+    discount_code_id: int = db.Column(db.Integer, db.ForeignKey('discount_codes.id', ondelete='SET NULL'),
                                  nullable=True, default=None)
     discount_code = db.relationship('DiscountCode', backref='event_invoices')
 
-    def __init__(self,
-                 amount=None,
-                 address=None,
-                 city=None,
-                 state=None,
-                 country=None,
-                 zipcode=None,
-                 transaction_id=None,
-                 paid_via=None,
-                 user_id=None,
-                 discount_code_id=None,
-                 event_id=None,
-                 invoice_pdf_url=None,
-                 payment_mode=None,
-                 brand=None,
-                 exp_month=None,
-                 exp_year=None,
-                 last4=None,
-                 stripe_token=None,
-                 paypal_token=None,
-                 deleted_at=None,
-                 status='due'
-                 ):
-        self.identifier = get_new_identifier()
-        self.amount = amount
-        self.address = address
-        self.state = state
-        self.country = country
-        self.zipcode = zipcode
-        self.city = city
-        self.user_id = user_id
-        self.event_id = event_id
-        self.transaction_id = transaction_id
-        self.paid_via = paid_via
-        self.created_at = datetime.utcnow()
-        self.discount_code_id = discount_code_id
-        self.status = status
-        self.invoice_pdf_url = invoice_pdf_url
-        self.payment_mode = payment_mode
-        self.brand = brand
-        self.exp_month = exp_month
-        self.exp_year = exp_year
-        self.last4 = last4
-        self.stripe_token = stripe_token
-        self.paypal_token = paypal_token
-        self.deleted_at = deleted_at
-
     def get_invoice_number(self):
         return 'I' + str(int(time.mktime(self.created_at.timetuple()))) + '-' + str(self.id)
-
-    def __repr__(self):
-        return '<EventInvoice %r>' % self.invoice_pdf_url
-
-    def __str__(self):
-        return self.__repr__()

--- a/app/models/event_location.py
+++ b/app/models/event_location.py
@@ -1,5 +1,6 @@
 import uuid
 
+from dataclasses import dataclass
 from app.api.helpers.db import get_count
 from app.models import db
 
@@ -13,24 +14,12 @@ def get_new_slug(name):
         return '{}-{}'.format(slug, uuid.uuid4().hex)
 
 
+@dataclass(init=True, repr=True, unsafe_hash=True)
 class EventLocation(db.Model):
     """Event location object table"""
 
     __tablename__ = 'event_locations'
 
-    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    name = db.Column(db.String, nullable=False)
-    slug = db.Column(db.String, unique=True, nullable=False)
-
-    def __init__(self,
-                 name=None,
-                 slug=None):
-
-        self.name = name
-        self.slug = get_new_slug(name=self.name)
-
-    def __repr__(self):
-        return '<EventLocation %r>' % self.slug
-
-    def __str__(self):
-        return self.__repr__()
+    id: int = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    name: str = db.Column(db.String, nullable=False)
+    slug: str = db.Column(db.String, unique=True, nullable=False)

--- a/app/models/event_orga.py
+++ b/app/models/event_orga.py
@@ -2,29 +2,19 @@ from app.models import db
 from app.models.base import SoftDeletionModel
 from datetime import datetime
 
+from dataclasses import dataclass
+
+@dataclass(init=True, repr=True, unsafe_hash=True)
 class EventOrgaModel(SoftDeletionModel):
     """Event Orga object table"""
 
     __tablename__ = 'events_orga'
 
-    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    name = db.Column(db.String, nullable=False)
-    starts_at = db.Column(db.DateTime(timezone=True))
-    payment_currency = db.Column(db.String, nullable=False)
+    id: int = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    name: str = db.Column(db.String, nullable=False)
+    starts_at: datetime = db.Column(db.DateTime(timezone=True))
+    payment_currency: str = db.Column(db.String, nullable=False)
 
-    def __init__(self,
-                 name=None,
-                 payment_currency=None):
-
-        self.name = name
-        self.starts_at = datetime.utcnow()
-        self.payment_currency = payment_currency
-
-    def __repr__(self):
-        return '<EventOrgaModel %r>' % self.name
-
-    def __str__(self):
-        return self.__repr__()
 
     @property
     def serialize(self):

--- a/app/models/event_sub_topic.py
+++ b/app/models/event_sub_topic.py
@@ -1,5 +1,6 @@
 import uuid
 
+from dataclasses import dataclass
 from app.api.helpers.db import get_count
 from app.models import db
 from app.models.base import SoftDeletionModel
@@ -14,6 +15,7 @@ def get_new_slug(name):
         return '{}-{}'.format(slug, uuid.uuid4().hex)
 
 
+@dataclass(init=True, repr=True, unsafe_hash=True)
 class EventSubTopic(SoftDeletionModel):
     """Event sub topic object table"""
 


### PR DESCRIPTION

Part of #6465

#### Short description of what this resolves:
 Moving to the dataclass architecture would prove to get rid of redundant `__init__`,` __repr__ `methods.
#### Changes proposed in this pull request:
Data classes in event_invoice, event_location, event, event_orga, event_copyright, event_sub_topic.
