### PR TITLE
chore(docs): Add CircleCI Build Status Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![GitHub release](https://img.shields.io/github/release/fossasia/open-event-server.svg)](https://github.com/fossasia/open-event-server/releases/latest)
 [![Build Status](https://travis-ci.org/fossasia/open-event-server.svg?branch=development)](https://travis-ci.org/fossasia/open-event-server)
+[![CircleCI Build Staus Badge](https://img.shields.io/circleci/build/github/fossasia/open-event-server?label=CircleCI%20Build)](https://www.circleci.com/gh/fossasia/open-event-server)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/1ac554483fac462797ffa5a8b9adf2fa?style=flat-square)](https://www.codacy.com/app/fossasia/open-event-server)
 [![Codecov branch](https://codecov.io/gh/fossasia/open-event-server/branch/master/graph/badge.svg?style=flat-square)](https://codecov.io/gh/fossasia/open-event-server)
 [![Gitter](https://img.shields.io/badge/chat-on%20gitter-ff006f.svg?style=flat-square)](https://gitter.im/fossasia/open-event-server)


### PR DESCRIPTION
I was able to find CircleCI's [own badge](https://www.circleci.com/gh/fossasia/open-event-server.svg) however the resolution of the `svg` file was too low, so I opted for the flat badge, generated at [shields.io](https://www.shields.io/), instead.

I would also like to point out that I noticed the "Deploy To Docker Cloud" link in the [#installation](https://github.com/fossasia/open-event-server#installation) section is not displayed correctly, however, I could not find another appropriate image to replace it.

Fixes #6527 

#### Short description of what this resolves:
- [x] Add CircleCI Build Status badge to [README.md](https://github.com/fossasia/open-event-server/blob/development/README.md)

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] ~~The unit tests pass locally with my changes~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added necessary documentation (if appropriate)~~
- [ ] ~~All the functions created/modified in this PR contain relevant docstrings.~~
