### PR TITLE
feat: add manage-scripts to switch system modules value

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,34 @@ Clone the repo and set up the server according to the steps listed. Make sure yo
 pip3 install -r requirements/tests.txt
 ```
 
+#### Enable/Disable modules
+
+-   Enable/Disable a specific module
+
+```
+python manage.py module --name module_name --switch on/off
+```
+
+**_Example :_**
+
+```
+python manage.py module --name ticket_include --switch on
+python manage.py module -n ticket_include -s off
+```
+
+-   Enable/Disable all modules
+
+```
+python manage.py module --name module_name --switch on/off
+```
+
+**_Example :_**
+
+```
+python manage.py module --name all --switch on
+python manage.py module -n all -s off
+```
+
 #### Running unit tests
 
 * Open Event uses Postgres database for testing. So set `DATABASE_URL` as a postgres database. Here is an example.

--- a/manage.py
+++ b/manage.py
@@ -6,6 +6,7 @@ from app import manager
 from app import current_app as app
 from app.models import db
 from app.models.speaker import Speaker
+from app.models.module import Module
 from populate_db import populate
 from flask_migrate import stamp
 from sqlalchemy.engine import reflection
@@ -34,6 +35,26 @@ def add_event_identifier():
     for event in events:
         event.identifier = get_new_event_identifier()
         save_to_db(event)
+
+
+@manager.option('-n', '--name', dest='name', default='all')
+@manager.option('-s', '--switch', dest='switch', default='off')
+def module(name, switch):
+    keys = [i.name for i in Module.__table__.columns][1:]
+    convey = {"on": True, "off": False}
+    if switch not in ['on', 'off']:
+        print("Choose either state On/Off")
+
+    elif name == 'all':
+        for key in keys:
+            setattr(Module.query.first(), key, convey[switch])
+            print("Module %s turned %s" % (key, switch))
+    elif name in keys:
+        setattr(Module.query.first(), name, convey[switch])
+        print("Module %s turned %s" % (name, switch))
+    else:
+        print("Invalid module selected")
+    db.session.commit()
 
 
 @manager.option('-e', '--event', help='Event ID. Eg. 1')


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6525  @prateekj117 @iamareebjamal 

#### Short description of what this resolves:
This adds a manage-script which helps the tester to switch any system module On/Off through command line

#### Changes proposed in this pull request:

- Added a manage command with the name switch 
- switch command provides the option to switch a specific module or all of them by specifying module_name or all
- Updated documentation in readme.md under the 'Testing' heading

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
