### PR TITLE
fixed the grammatical mistake in step 2 of local installation docs

### DIFF
--- a/docs/installation/local.md
+++ b/docs/installation/local.md
@@ -93,7 +93,7 @@ pipenv shell
 ```
 
 
-* **Step 2** - Create the database. For that we first open the psql shell. Go the directory where your postgres file is stored.
+* **Step 2** - Create the database. For that we first open the psql shell. Go to the directory where your postgres file is stored.
 
 ```sh
 # For linux users


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6552 

#### Short description of what this resolves:
- Fixed the grammatical error of step 2 in local installation document 
![Screenshot from 2019-10-26 14-27-06](https://user-images.githubusercontent.com/46647141/67617229-a98f3780-f7fe-11e9-99a7-3cba03e41572.png)


#### Changes proposed in this pull request:

- Added Missing "to" in step 2 of local.md file in /docs/installation

![Screenshot from 2019-10-26 14-27-06](https://user-images.githubusercontent.com/46647141/67617236-ba3fad80-f7fe-11e9-956e-cc80dd5dafa8.png)


