### PR TITLE
chore(docs): Fix grammatical mistakes in docs

### DIFF
--- a/docs/installation/local.md
+++ b/docs/installation/local.md
@@ -93,7 +93,7 @@ pipenv shell
 ```
 
 
-* **Step 2** - Create the database. For that we first open the psql shell. Go the directory where your postgres file is stored.
+* **Step 2** - Create the database. For that we first open the psql shell. Go to the directory where your postgres file is stored.
 
 ```sh
 # For linux users


### PR DESCRIPTION
fixes #6552 

#### Short description of what this resolves:
This PR replaces the text:
Go the directory where your postgres file is stored.
inside docs/installation/local.md, with the text:
Go to the directory where your postgres file is stored.
In short, it corrects a grammar mistake.
For more information, read [this.](https://github.com/fossasia/open-event-server/issues/6552#issue-512805276)
- [x] I have read the [Cont
ribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
