### PR TITLE
fix: Error while running `python3 manage.py list_routes`

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -21,7 +21,7 @@ def list_routes():
     output = []
     for rule in app.url_map.iter_rules():
         methods = ','.join(rule.methods)
-        line = urllib.unquote("{:50s} {:20s} {}".format(
+        line = urllib.parse.unquote("{:50s} {:20s} {}".format(
             rule.endpoint, methods, rule))
         output.append(line)
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6579 

#### Short description of what this resolves:
`unquote` attribute is now in `urllib.parse`

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [X] All the functions created/modified in this PR contain relevant docstrings.
