### PR TITLE
feat: Optimize link generation

### DIFF
--- a/app/api/schema/__init__.py
+++ b/app/api/schema/__init__.py
@@ -7,4 +7,5 @@ def serialize(self, attr, obj, accessor=None):
         return super().serialize(attr, obj, accessor)
     return self._serialize(None, attr, obj)
 
+
 Relationship.serialize = serialize

--- a/app/api/schema/__init__.py
+++ b/app/api/schema/__init__.py
@@ -1,0 +1,10 @@
+# Monkey Patch Marshmallow JSONAPI
+from marshmallow_jsonapi.flask import Relationship
+
+
+def serialize(self, attr, obj, accessor=None):
+    if self.include_resource_linkage or self.include_data:
+        return super().serialize(attr, obj, accessor)
+    return self._serialize(None, attr, obj)
+
+Relationship.serialize = serialize

--- a/app/api/schema/__init__.py
+++ b/app/api/schema/__init__.py
@@ -4,7 +4,7 @@ from marshmallow_jsonapi.flask import Relationship
 
 def serialize(self, attr, obj, accessor=None):
     if self.include_resource_linkage or self.include_data:
-        return super().serialize(attr, obj, accessor)
+        return super(Relationship, self).serialize(attr, obj, accessor)
     return self._serialize(None, attr, obj)
 
 

--- a/app/api/schema/users.py
+++ b/app/api/schema/users.py
@@ -100,7 +100,7 @@ class UserSchema(UserSchemaPublic):
         type_='feedback')
     event_invoice = Relationship(
         attribute='event_invoice',
-        self_view='v1.user_event_invoice',
+        self_view='v1.user_event_invoices',
         self_view_kwargs={'id': '<id>'},
         related_view='v1.event_invoice_list',
         related_view_kwargs={'user_id': '<id>'},


### PR DESCRIPTION
Related: #6666 
Upstream: https://github.com/marshmallow-code/marshmallow-jsonapi/pull/278

Before:
/v1/events/ = 2.7 seconds == 2700 ms (20 events)
/v1/events/<id> = 250 ms

After:
/v1/events/ = 150 ms (20 events)
/v1/events/<id> = 30 ms