### PR TITLE
chore: Remove flask limiter warning

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -18,6 +18,7 @@ from flask_script import Manager
 from flask_login import current_user
 from flask_jwt_extended import JWTManager
 from flask_limiter import Limiter
+from flask_limiter.util import get_ipaddr
 from datetime import timedelta
 from flask_cors import CORS
 from flask_rest_jsonapi.errors import jsonapi_errors
@@ -56,7 +57,7 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 static_dir = os.path.dirname(os.path.dirname(__file__)) + "/static"
 template_dir = os.path.dirname(__file__) + "/templates"
 app = Flask(__name__, static_folder=static_dir, template_folder=template_dir)
-limiter = Limiter(app)
+limiter = Limiter(app, key_func=get_ipaddr)
 env.read_envfile()
 
 

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -13,7 +13,6 @@ from flask_jwt_extended import (
     current_user, create_access_token,
     create_refresh_token, set_refresh_cookies,
     get_jwt_identity)
-from flask_limiter.util import get_remote_address
 from healthcheck import EnvironmentDump
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -289,7 +288,7 @@ def resend_verification_email():
     '3/hour', key_func=lambda: request.json['data']['email'], error_message='Limit for this action exceeded'
 )
 @limiter.limit(
-    '1/minute', key_func=get_remote_address, error_message='Limit for this action exceeded'
+    '1/minute', error_message='Limit for this action exceeded'
 )
 def reset_password_post():
     try:

--- a/app/api/custom/orders.py
+++ b/app/api/custom/orders.py
@@ -1,6 +1,5 @@
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import current_user, jwt_required
-from flask_limiter.util import get_remote_address
 from sqlalchemy.orm.exc import NoResultFound
 
 
@@ -50,7 +49,7 @@ def ticket_attendee_authorized(order_identifier):
     '5/minute', key_func=lambda: request.json['data']['user'], error_message='Limit for this action exceeded'
 )
 @limiter.limit(
-    '60/minute', key_func=get_remote_address, error_message='Limit for this action exceeded'
+    '60/minute', error_message='Limit for this action exceeded'
 )
 def resend_emails():
     """


### PR DESCRIPTION
Remove warning for default usage of `get_ipaddr` function