### PR TITLE
chore: run container script run through CLI args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ WORKDIR /data/app
 ADD . .
 
 EXPOSE 8080
-CMD ["sh", "scripts/container_start.sh"]
+ENTRYPOINT ["sh", "scripts/container_start.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,8 +53,8 @@ services:
     container_name: opev-celery
     environment:
       <<: *environment-vars
-      DEPLOYMENT: celery
       C_FORCE_ROOT: "true"
+    command: celery
 
 volumes:
     pg:

--- a/scripts/container_start.sh
+++ b/scripts/container_start.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-export DEPLOYMENT=${DEPLOYMENT:-api}
+export DEPLOYMENT=${1:-api}
 
 echo "[LOG] Deploying ${DEPLOYMENT}"
 echo "[LOG] Using database: ${DATABASE_URL}"
@@ -18,6 +18,7 @@ then
     echo "[LOG] Starting gunicorn on port ${PORT}"
     gunicorn -b 0.0.0.0:${PORT} app:app -w $GUNICORN_WORKERS --enable-stdio-inheritance --log-level $GUNICORN_LOG_LEVEL --proxy-protocol --preload $GUNICORN_EXTRA_ARGS
 fi
+
 if [ "$DEPLOYMENT" == "celery" ]
 then
     echo "[LOG] Starting celery worker"


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6598

#### Short description of what this resolves:

Container script now can be run by CLI args instead of envt variables


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.
