### PR TITLE
fix: count query of sold tickets

### DIFF
--- a/app/factories/attendee.py
+++ b/app/factories/attendee.py
@@ -7,14 +7,11 @@ from app.factories.order import OrderFactory
 from app.models.ticket_holder import db, TicketHolder
 
 
-class AttendeeFactory(factory.alchemy.SQLAlchemyModelFactory):
+class AttendeeFactoryBase(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = TicketHolder
         sqlalchemy_session = db.session
 
-    event = factory.RelatedFactory(EventFactoryBasic)
-    ticket = factory.RelatedFactory(TicketFactory)
-    order = factory.RelatedFactory(OrderFactory)
     firstname = common.string_
     lastname = common.string_
     email = common.email_
@@ -29,3 +26,9 @@ class AttendeeFactory(factory.alchemy.SQLAlchemyModelFactory):
     order_id = None
     created_at = common.date_
     modified_at = common.date_
+
+
+class AttendeeFactory(AttendeeFactoryBase):
+    event = factory.RelatedFactory(EventFactoryBasic)
+    ticket = factory.RelatedFactory(TicketFactory)
+    order = factory.RelatedFactory(OrderFactory)

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -91,6 +91,7 @@ class Order(SoftDeletionModel):
                  transaction_id=None,
                  paid_via=None,
                  is_billing_enabled=False,
+                 created_at=datetime.datetime.now(datetime.timezone.utc),
                  user_id=None,
                  discount_code_id=None,
                  event_id=None,
@@ -114,7 +115,7 @@ class Order(SoftDeletionModel):
         self.transaction_id = transaction_id
         self.paid_via = paid_via
         self.is_billing_enabled = is_billing_enabled
-        self.created_at = datetime.datetime.now(datetime.timezone.utc)
+        self.created_at = created_at
         self.discount_code_id = discount_code_id
         self.status = status
         self.payment_mode = payment_mode

--- a/tests/all/integration/api/helpers/test_order.py
+++ b/tests/all/integration/api/helpers/test_order.py
@@ -3,13 +3,15 @@ from datetime import timedelta, datetime, timezone
 
 from app.settings import get_settings
 from app import current_app as app, db
-from app.api.helpers.db import save_to_db
 from app.api.helpers.order import set_expiry_for_order, delete_related_attendees_for_order
-from app.factories.attendee import AttendeeFactory
+import app.factories.common as common
+from app.factories.attendee import AttendeeFactoryBase, AttendeeFactory
 from app.factories.event import EventFactoryBasic
+from app.factories.ticket import TicketFactory
 from app.factories.order import OrderFactory
 from app.models.order import Order
 from app.api.helpers.db import save_to_db
+from app.api.attendees import get_sold_and_reserved_tickets_count
 from tests.all.integration.setup_database import Setup
 from tests.all.integration.utils import OpenEventTestCase
 
@@ -53,6 +55,42 @@ class TestOrderUtilities(OpenEventTestCase):
             delete_related_attendees_for_order(obj)
             order = db.session.query(Order).filter(Order.id == obj.id).first()
             self.assertEqual(len(order.ticket_holders), 0)
+
+    def test_count_sold_and_reserved_tickets(self):
+        """Method to test the count query of sold tickets"""
+
+        with app.test_request_context():
+            ticket = TicketFactory()
+
+            completed_order = OrderFactory(status='completed')
+            placed_order = OrderFactory(status='placed')
+            initializing_order = OrderFactory(status='initializing',
+                                              created_at=datetime.utcnow() - timedelta(minutes=5))
+            pending_order = OrderFactory(status='pending',
+                                         created_at=datetime.utcnow() - timedelta(minutes=35))
+            expired_time_order = OrderFactory(status='initializing', created_at=common.date_)
+            expired_order = OrderFactory(status='expired')
+
+            db.session.commit()
+
+            # will not be counted as they have no order_id
+            AttendeeFactoryBase.create_batch(2)
+            # will be counted as attendee have valid orders
+            AttendeeFactoryBase.create_batch(6, order_id=completed_order.id)
+            # will be counted as attendee has valid placed order
+            AttendeeFactoryBase(order_id=placed_order.id)
+            # will be counted as attendee has initializing order under order expiry time
+            AttendeeFactoryBase.create_batch(4, order_id=initializing_order.id)
+            # will be counted as attendee has pending order under 30+order expiry time
+            AttendeeFactoryBase.create_batch(2, order_id=pending_order.id)
+            # will not be counted as the order is not under order expiry time
+            AttendeeFactoryBase.create_batch(3, order_id=expired_time_order.id)
+            # will not be counted as the order has an expired state
+            AttendeeFactoryBase.create_batch(5, order_id=expired_order.id)
+
+            count = get_sold_and_reserved_tickets_count(ticket.event_id)
+
+            self.assertEqual(count, 13)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6653 

https://github.com/fossasia/open-event-server/issues/6653#issuecomment-565030517


#### Short description of what this resolves:

Count query of sold tickets. Solution: Calculate only placed orders + initializing orders which were created under order expiry time

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.
