### PR TITLE
fix: AWS file upload

### DIFF
--- a/app/api/helpers/storage.py
+++ b/app/api/helpers/storage.py
@@ -99,7 +99,16 @@ class UploadedFile:
     def __init__(self, file_path, filename):
         self.file_path = file_path
         self.filename = filename
-        self.file = open(file_path)
+        self.file = open(file_path, 'rb')
+
+    def __len__(self):
+        position = self.file.tell()
+        try:
+            self.file.seek(0, os.SEEK_END)
+            last_position = self.file.tell()
+        finally:
+            self.file.seek(position)
+        return last_position
 
     def save(self, new_path):
         copyfile(self.file_path, new_path)

--- a/app/api/helpers/storage.py
+++ b/app/api/helpers/storage.py
@@ -233,15 +233,15 @@ def upload_to_aws(bucket_name, aws_region, aws_key, aws_secret, file, key, acl='
         item.delete()
     # set object settings
 
-    file_data = file.read()
-    file_mime = magic.from_buffer(file_data, mime=True)
-    size = len(file_data)
-    sent = k.set_contents_from_string(
-        file_data,
+    file_mime = magic.from_file(file.file_path, mime=True)
+    size = len(file)
+    sent = k.set_contents_from_file(
+        file.file,
         headers={
             'Content-Disposition': 'attachment; filename=%s' % filename,
             'Content-Type': '%s' % file_mime
-        }
+        },
+        rewind=True
     )
     k.set_acl(acl)
     s3_url = 'https://%s.s3.amazonaws.com/' % bucket_name

--- a/tests/all/unit/api/helpers/test_storage.py
+++ b/tests/all/unit/api/helpers/test_storage.py
@@ -1,8 +1,10 @@
 """Test file for storage functions."""
+import os
+from tempfile import TemporaryDirectory
 import unittest
 from unittest.mock import patch
 
-from app.api.helpers.storage import create_url, generate_hash
+from app.api.helpers.storage import create_url, generate_hash, UploadedFile
 
 
 class TestStorageHelperValidation(unittest.TestCase):
@@ -63,6 +65,21 @@ class TestStorageHelperValidation(unittest.TestCase):
             actual_output = generate_hash(test_input)
             self.assertEqual(exepected_output, actual_output)
             self.assertEqual(len(actual_output), 10)
+
+
+class TestUploadedFile(unittest.TestCase):
+    test_data = b'\xffhellothere'
+
+    def _uploaded_file(self, folder, filename='testfile.bin'):
+        path = os.path.join(folder, filename)
+        with open(path, 'wb') as f:
+            f.write(self.test_data)
+        return UploadedFile(path, filename)
+
+    def test_read(self):
+        with TemporaryDirectory() as folder:
+            file = self._uploaded_file(folder)
+            self.assertEqual(file.read(), self.test_data)
 
 
 if __name__ == '__main__':

--- a/tests/all/unit/api/helpers/test_storage.py
+++ b/tests/all/unit/api/helpers/test_storage.py
@@ -76,6 +76,11 @@ class TestUploadedFile(unittest.TestCase):
             f.write(self.test_data)
         return UploadedFile(path, filename)
 
+    def test_len(self):
+        with TemporaryDirectory() as folder:
+            file = self._uploaded_file(folder)
+            self.assertEqual(len(file), len(self.test_data))
+
     def test_read(self):
         with TemporaryDirectory() as folder:
             file = self._uploaded_file(folder)


### PR DESCRIPTION
Fixes #6706 

#### Short description of what this resolves:

* With this fix, I can upload images to aws storage without the failure described in #6706.
* Might reduce memory consumption when uploading large images.

#### Changes proposed in this pull request:

- In storage helper, open uploaded files as bytestream 'rb' instead of unicode
- For aws storage, avoid re-loading the data to memory (use the fileobject for the boto call).

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/all` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] All the functions created/modified in this PR contain relevant docstrings.
