### PR TITLE
fix: sessions cannot be edited after cfs ends

### DIFF
--- a/app/api/helpers/speaker.py
+++ b/app/api/helpers/speaker.py
@@ -1,0 +1,21 @@
+from app.models.speakers_call import SpeakersCall
+from app.api.helpers.permission_manager import has_access
+from app.api.helpers.exceptions import ForbiddenException
+
+from datetime import datetime
+
+
+def can_edit_after_cfs_ends(event_id):
+    """
+    Method to check that user has permission to edit the speaker or session
+    after the CFS ends
+    """
+    speakers_call = SpeakersCall.query.filter_by(event_id=event_id, deleted_at=None).one()
+    if speakers_call:
+        speakers_call_tz = speakers_call.ends_at.tzinfo
+        return not(speakers_call.ends_at <= datetime.now().replace(tzinfo=speakers_call_tz)
+            and not (has_access('is_admin') or has_access('is_organizer', event_id=event_id) or
+                     has_access('is_coorganizer', event_id=event_id)))
+    else:
+        raise ForbiddenException({'source': '/data/event-id'},
+                                 'Speaker Calls for event {id} not found'.format(id=event_id))

--- a/app/api/speakers.py
+++ b/app/api/speakers.py
@@ -9,6 +9,7 @@ from app.api.helpers.exceptions import ForbiddenException
 from app.api.helpers.permission_manager import has_access
 from app.api.helpers.query import event_query
 from app.api.helpers.utilities import require_relationship
+from app.api.helpers.speaker import can_edit_after_cfs_ends
 from app.api.schema.speakers import SpeakerSchema
 from app.models import db
 from app.models.event import Event
@@ -132,6 +133,10 @@ class SpeakerDetail(ResourceDetail):
         :param view_kwargs:
         :return:
         """
+        if not can_edit_after_cfs_ends(speaker.event_id):
+            raise ForbiddenException({'source': ''},
+                                     "Cannot edit speaker after the call for speaker is ended")
+
         if data.get('photo_url') and data['photo_url'] != speaker.photo_url:
             start_image_resizing_tasks(speaker, data['photo_url'])
 

--- a/tests/hook_main.py
+++ b/tests/hook_main.py
@@ -1068,6 +1068,8 @@ def session_patch(transaction):
     """
     with stash['app'].app_context():
         session = SessionFactory()
+        speakers_call = SpeakersCallFactory()
+        db.session.add(speakers_call)
         db.session.add(session)
         db.session.commit()
 
@@ -1081,6 +1083,8 @@ def session_delete(transaction):
     """
     with stash['app'].app_context():
         session = SessionFactory()
+        speakers_call = SpeakersCallFactory()
+        db.session.add(speakers_call)
         db.session.add(session)
         db.session.commit()
 

--- a/tests/hook_main.py
+++ b/tests/hook_main.py
@@ -1269,6 +1269,8 @@ def speaker_patch(transaction):
     """
     with stash['app'].app_context():
         speaker = SpeakerFactory()
+        speakers_call = SpeakersCallFactory()
+        db.session.add(speakers_call)
         db.session.add(speaker)
         db.session.commit()
 
@@ -1282,6 +1284,8 @@ def speaker_delete(transaction):
     """
     with stash['app'].app_context():
         speaker = SpeakerFactory()
+        speakers_call = SpeakersCallFactory()
+        db.session.add(speakers_call)
         db.session.add(speaker)
         db.session.commit()
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6726 

#### Short description of what this resolves:
fix: sessions cannot be edited after cfs ends


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.
