### PR TITLE
fix: add check if donation ticket has payment method enabled

### DIFF
--- a/app/api/tickets.py
+++ b/app/api/tickets.py
@@ -70,7 +70,7 @@ class TicketListPost(ResourceList):
                     {'event_id': data['event']}, "Event does not exist"
                 )
 
-            if data.get('type') == 'paid':
+            if data.get('type') == 'paid' or data.get('type') == 'donation':
                 if not event.is_payment_enabled():
                     raise UnprocessableEntity(
                         {'event_id': data['event']},
@@ -231,7 +231,7 @@ class TicketDetail(ResourceDetail):
         :param view_kwargs:
         :return:
         """
-        if ticket.type == 'paid':
+        if ticket.type == 'paid' or ticket.type == 'donation':
             try:
                 event = (
                     db.session.query(Event)


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6788 

#### Short description of what this resolves:

Server will throw an error `Donation ticket must have a payment method` as it throws in case of `Paid Tickets`
