### PR TITLE
Revert "fix: returning duplicated sessions"

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -126,7 +126,7 @@ class SessionList(ResourceList):
         if view_kwargs.get('user_id') is not None:
             user = safe_query(self, User, 'id', view_kwargs['user_id'], 'user_id')
             query_ = (
-                query_.distinct(Session.id).join(User)
+                query_.join(User)
                 .join(Speaker)
                 .filter(
                     (


### PR DESCRIPTION
Reverts fossasia/open-event-server#6792

- This PR broke the my sessions route

```py
The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/sentry_sdk/integrations/flask.py", line 70, in sentry_patched_wsgi_app
    environ, start_response
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/sentry_sdk/integrations/wsgi.py", line 120, in __call__
    reraise(*_capture_exception(hub))
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/sentry_sdk/_compat.py", line 57, in reraise
    raise value
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/sentry_sdk/integrations/wsgi.py", line 116, in __call__
    _sentry_start_response, start_response, span
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/sentry_sdk/integrations/flask.py", line 69, in <lambda>
    return SentryWsgiMiddleware(lambda *a, **kw: old_app(self, *a, **kw))(
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/flask/app.py", line 2463, in __call__
    return self.wsgi_app(environ, start_response)
  File "/Users/kush/open-event-server/app/instance.py", line 69, in __call__
    return self.app(environ, start_response)
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/flask/app.py", line 2449, in wsgi_app
    response = self.handle_exception(e)
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/flask_cors/extension.py", line 161, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/flask_cors/extension.py", line 161, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/flask/app.py", line 1866, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/flask/app.py", line 2446, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/flask/app.py", line 1951, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/flask_cors/extension.py", line 161, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/flask_cors/extension.py", line 161, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/flask/app.py", line 1820, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/Users/kush/open-event-server/venv/src/flask-rest-jsonapi/flask_rest_jsonapi/decorators.py", line 32, in wrapper
    return func(*args, **kwargs)
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/flask/views.py", line 89, in view
    return self.dispatch_request(*args, **kwargs)
  File "/Users/kush/open-event-server/venv/src/flask-rest-jsonapi/flask_rest_jsonapi/resource.py", line 68, in dispatch_request
    response = method(*args, **kwargs)
  File "/Users/kush/open-event-server/venv/src/flask-rest-jsonapi/flask_rest_jsonapi/decorators.py", line 56, in wrapper
    return func(*args, **kwargs)
  File "/Users/kush/open-event-server/venv/src/flask-rest-jsonapi/flask_rest_jsonapi/resource.py", line 143, in get
    objects_count, objects = self._data_layer.get_collection(qs, kwargs)
  File "/Users/kush/open-event-server/venv/src/flask-rest-jsonapi/flask_rest_jsonapi/data_layers/alchemy.py", line 102, in get_collection
    object_count = query.count()
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/sqlalchemy/orm/query.py", line 3653, in count
    return self.from_self(col).scalar()
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/sqlalchemy/orm/query.py", line 3377, in scalar
    ret = self.one()
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/sqlalchemy/orm/query.py", line 3347, in one
    ret = self.one_or_none()
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/sqlalchemy/orm/query.py", line 3316, in one_or_none
    ret = list(self)
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/sqlalchemy/orm/query.py", line 3389, in __iter__
    return self._execute_and_instances(context)
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/sqlalchemy/orm/query.py", line 3414, in _execute_and_instances
    result = conn.execute(querycontext.statement, self._params)
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 982, in execute
    return meth(self, multiparams, params)
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/sqlalchemy/sql/elements.py", line 293, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1101, in _execute_clauseelement
    distilled_params,
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1250, in _execute_context
    e, statement, parameters, cursor, context
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1476, in _handle_dbapi_exception
    util.raise_from_cause(sqlalchemy_exception, exc_info)
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 398, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb, cause=cause)
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 152, in reraise
    raise value.with_traceback(tb)
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1246, in _execute_context
    cursor, statement, parameters, context
  File "/Users/kush/open-event-server/venv/lib/python3.7/site-packages/sqlalchemy/engine/default.py", line 588, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.InvalidColumnReference) SELECT DISTINCT ON expressions must match initial ORDER BY expressions
LINE 2: FROM (SELECT DISTINCT ON (sessions.id) sessions.deleted_at A...
                                  ^

[SQL: SELECT count(*) AS count_1
FROM (SELECT DISTINCT ON (sessions.id) sessions.deleted_at AS sessions_deleted_at, sessions.id AS sessions_id, sessions.title AS sessions_title, sessions.subtitle AS sessions_subtitle, sessions.short_abstract AS sessions_short_abstract, sessions.long_abstract AS sessions_long_abstract, sessions.comments AS sessions_comments, sessions.language AS sessions_language, sessions.level AS sessions_level, sessions.starts_at AS sessions_starts_at, sessions.ends_at AS sessions_ends_at, sessions.track_id AS sessions_track_id, sessions.microlocation_id AS sessions_microlocation_id, sessions.session_type_id AS sessions_session_type_id, sessions.slides_url AS sessions_slides_url, sessions.video_url AS sessions_video_url, sessions.audio_url AS sessions_audio_url, sessions.signup_url AS sessions_signup_url, sessions.event_id AS sessions_event_id, sessions.creator_id AS sessions_creator_id, sessions.state AS sessions_state, sessions.created_at AS sessions_created_at, sessions.submitted_at AS sessions_submitted_at, sessions.submission_modifier AS sessions_submission_modifier, sessions.is_mail_sent AS sessions_is_mail_sent, sessions.last_modified_at AS sessions_last_modified_at, sessions.send_email AS sessions_send_email, sessions.is_locked AS sessions_is_locked, sessions.complex_field_values AS sessions_complex_field_values
FROM sessions JOIN users ON users.id = sessions.creator_id JOIN speaker ON users.id = speaker.user_id
WHERE (EXISTS (SELECT 1
FROM speakers_sessions, speaker
WHERE sessions.id = speakers_sessions.session_id AND speaker.id = speakers_sessions.speaker_id AND speaker.user_id = %(user_id_1)s)) AND sessions.deleted_at IS NULL AND (sessions.starts_at >= %(starts_at_1)s OR sessions.starts_at IS NULL AND sessions.ends_at IS NULL AND (EXISTS (SELECT 1
FROM events
WHERE events.id = sessions.event_id AND events.starts_at >= %(starts_at_2)s))) ORDER BY sessions.starts_at ASC) AS anon_1]
[parameters: {'user_id_1': 1, 'starts_at_1': '2020-01-27T08:14:12.914Z', 'starts_at_2': '2020-01-27T08:14:12.914Z'}]
(Background on this error at: http://sqlalche.me/e/f405)

```