### PR TITLE
chore: Pin werkzeug version

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -8,6 +8,7 @@ Flask-Login~=0.4
 Flask-Scrypt~=0.1.3
 flask-jwt-extended~=3.24.1
 flask-celeryext~=0.3
+werkzeug~=0.16.1
 omise~=0.8.1
 requests-oauthlib~=1.3
 icalendar~=4.0.4


### PR DESCRIPTION
Since we are directly depending on werkzeug, it should
be tracked in requirements file so that transitive upgrade
does not break the project
