### PR TITLE
chore: bump flask-admin to 1.5.5

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -49,7 +49,7 @@ blinker~=1.4
 envparse~=0.2
 git+https://github.com/fossasia/flask-rest-jsonapi@0.12.6.1
 wtforms~=2.2
-flask-admin~=1.5
+flask-admin~=1.5.5
 google-compute-engine~=2.8
 factory_boy~=2.12
 sentry-sdk[flask]~=0.14


### PR DESCRIPTION
Bump flask-admin so that it works with werkzeug 1.0