### PR TITLE
chore: Update max line length in .deepsource.toml

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -10,6 +10,7 @@ enabled = true
 
   [analyzers.meta]
   runtime_version = "3.x.x"
+  max_line_length = 90
 
 [[analyzers]]
 name = "test-coverage"


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6978  

#### Short description of what this resolves:
This PR adds max_line_check = 90 to ``.deepsource.toml``

#### Changes proposed in this pull request:

By default, DeepSource checks max line length for python file to be 88. However, this can be updated as per the project requirement by adding a line ``max_line_check`` under ``[analyzers.meta]`` tag in ``.deepsource.toml``.

Refer https://deepsource.io/docs/analyzer/python.html#configuration-deepsource-toml

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
