### PR TITLE
docs: Add redis start command for macOS

### DIFF
--- a/docs/installation/local.md
+++ b/docs/installation/local.md
@@ -159,6 +159,7 @@ sudo dnf install redis
 
 # For macOS
 brew install redis
+brew services start redis
 
 # Run Celery
 # socketio has problems with celery "blocking" tasks


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->



#### Short description of what this resolves:

Added redis start command for macOS without which celery won't connect.

#### Changes proposed in this pull request:

- Added command `brew services start redis`
- The initial readme points to local.md in which there was the absence of this command


#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
