### PR TITLE
fix: Make order amount calculation order agnostic

### DIFF
--- a/app/api/helpers/order.py
+++ b/app/api/helpers/order.py
@@ -187,6 +187,7 @@ def calculate_order_amount(tickets, discount_code=None):
     from app.api.helpers.ticketing import validate_tickets, validate_discount_code
 
     ticket_ids = [ticket['id'] for ticket in tickets]
+    ticket_map = {int(ticket['id']): ticket for ticket in tickets}
     fetched_tickets = validate_tickets(ticket_ids)
 
     if tickets and discount_code:
@@ -195,7 +196,8 @@ def calculate_order_amount(tickets, discount_code=None):
     event = tax = tax_included = fees = None
     total_amount = total_tax = total_discount = 0.0
     ticket_list = []
-    for ticket_info, ticket in zip(tickets, fetched_tickets):
+    for ticket in fetched_tickets:
+        ticket_info = ticket_map[ticket.id]
         discount_amount = 0.0
         discount_data = None
         ticket_fee = 0.0

--- a/tests/all/integration/api/helpers/order/test_calculate_order_amount.py
+++ b/tests/all/integration/api/helpers/order/test_calculate_order_amount.py
@@ -66,7 +66,7 @@ def test_multiple_tickets(db):
     ticket3 = TicketSubFactory(price=233.15, event=ticket.event)
     db.session.commit()
 
-    tickets = _create_ticket_dict([ticket, ticket2, ticket3], [3, 1, 2])
+    tickets = _create_ticket_dict([ticket3, ticket2, ticket], [2, 1, 3])
 
     amount_data = calculate_order_amount(tickets)
 
@@ -98,7 +98,7 @@ def _create_donation_tickets(db):
     )
     db.session.commit()
 
-    return _create_ticket_dict(tickets, [3, 1, 2])
+    return _create_ticket_dict(tickets[::-1], [2, 1, 3])
 
 
 def _expect_donation_error(ticket_dict):
@@ -131,7 +131,7 @@ def test_donation_ticket_with_higher_price(db):
 
 def test_donation_ticket(db):
     ticket_dict = _create_donation_tickets(db)
-    ticket_dict[-1]['price'] = 15.13
+    ticket_dict[0]['price'] = 15.13
 
     amount_data = calculate_order_amount(ticket_dict)
 


### PR DESCRIPTION
Previously, order amount calculation was dependent on the order of ticket IDs passed, so it calculated wrong quantity of tickets depending upon the order of the ticket ID instead of ticket ID itself