### PR TITLE
feat: Expire initializing attendees automatically

### DIFF
--- a/app/api/helpers/scheduled_jobs.py
+++ b/app/api/helpers/scheduled_jobs.py
@@ -217,14 +217,16 @@ def expire_initializing_tickets():
         (Order.created_at + datetime.timedelta(minutes=order_expiry_time))
         <= datetime.datetime.now(datetime.timezone.utc),
     )
+    # pytype: disable=attribute-error
     TicketHolder.query.filter(TicketHolder.order_id.in_(query.subquery())).delete(
         synchronize_session=False
     )
+    # pytype: enable=attribute-error
     query.update({'status': 'expired'})
 
     try:
         db.session.commit()
-    except:
+    except Exception:
         db.session.rollback()
         raise
 

--- a/tests/all/integration/api/helpers/test_scheduled_jobs.py
+++ b/tests/all/integration/api/helpers/test_scheduled_jobs.py
@@ -9,21 +9,17 @@ from app.api.helpers.scheduled_jobs import (
     expire_pending_tickets,
     send_monthly_event_invoice,
 )
-from app.models import db
 from app.models.event_invoice import EventInvoice
 from app.models.ticket_holder import TicketHolder
 from app.settings import get_settings
-from tests.all.integration.utils import OpenEventLegacyTestCase
 from tests.factories.attendee import (
     AttendeeFactoryBase,
     AttendeeOrderSubFactory,
     AttendeeSubFactory,
 )
-from tests.factories.event import EventFactoryBasic
 from tests.factories.event_invoice import EventInvoiceSubFactory
 from tests.factories.order import OrderSubFactory
 from tests.factories.ticket_fee import TicketFeesFactory
-from tests.factories.user import UserFactory
 
 
 def test_delete_ticket_holder_created_currently(db):

--- a/tests/all/integration/api/helpers/test_scheduled_jobs.py
+++ b/tests/all/integration/api/helpers/test_scheduled_jobs.py
@@ -15,14 +15,13 @@ from app.models.ticket_holder import TicketHolder
 from app.settings import get_settings
 from tests.all.integration.utils import OpenEventLegacyTestCase
 from tests.factories.attendee import (
-    AttendeeFactory,
     AttendeeFactoryBase,
     AttendeeOrderSubFactory,
     AttendeeSubFactory,
 )
 from tests.factories.event import EventFactoryBasic
-from tests.factories.event_invoice import EventInvoiceFactory, EventInvoiceSubFactory
-from tests.factories.order import OrderFactory, OrderSubFactory
+from tests.factories.event_invoice import EventInvoiceSubFactory
+from tests.factories.order import OrderSubFactory
 from tests.factories.ticket_fee import TicketFeesFactory
 from tests.factories.user import UserFactory
 
@@ -99,7 +98,7 @@ def test_send_monthly_invoice(db):
         completed_at=datetime.datetime.now() - datetime.timedelta(days=30),
         amount=100,
     )
-    test_ticket_holder = AttendeeSubFactory(event=test_order.event, order=test_order)
+    AttendeeSubFactory(event=test_order.event, order=test_order)
     db.session.commit()
 
     send_monthly_event_invoice()
@@ -113,9 +112,9 @@ def test_expire_initializing_tickets(db):
         created_at=datetime.datetime.now(timezone.utc)
         - timedelta(minutes=order_expiry_time)
     )
-    attendees_old = AttendeeSubFactory.create_batch(3, order=order_old)
+    AttendeeSubFactory.create_batch(3, order=order_old)
     order_new = OrderSubFactory()
-    attendees_new = AttendeeSubFactory.create_batch(2, order=order_new)
+    AttendeeSubFactory.create_batch(2, order=order_new)
     db.session.commit()
 
     expire_initializing_tickets()
@@ -131,12 +130,12 @@ def test_expire_pending_tickets(db):
         status='pending',
         created_at=datetime.datetime.now(timezone.utc) - timedelta(minutes=45),
     )
-    attendees_old = AttendeeSubFactory.create_batch(3, order=order_old)
+    AttendeeSubFactory.create_batch(3, order=order_old)
     order_new = OrderSubFactory(
         status='pending',
         created_at=datetime.datetime.now(timezone.utc) - timedelta(minutes=15),
     )
-    attendees_new = AttendeeSubFactory.create_batch(2, order=order_new)
+    AttendeeSubFactory.create_batch(2, order=order_new)
     db.session.commit()
 
     expire_pending_tickets()

--- a/tests/all/integration/api/helpers/test_scheduled_jobs.py
+++ b/tests/all/integration/api/helpers/test_scheduled_jobs.py
@@ -1,113 +1,147 @@
 import datetime
+from datetime import timedelta, timezone
 
 import tests.factories.common as common
 from app.api.helpers.scheduled_jobs import (
     delete_ticket_holders_no_order_id,
     event_invoices_mark_due,
+    expire_initializing_tickets,
+    expire_pending_tickets,
     send_monthly_event_invoice,
 )
 from app.models import db
 from app.models.event_invoice import EventInvoice
 from app.models.ticket_holder import TicketHolder
+from app.settings import get_settings
 from tests.all.integration.utils import OpenEventLegacyTestCase
-from tests.factories.attendee import AttendeeFactory
+from tests.factories.attendee import (
+    AttendeeFactory,
+    AttendeeFactoryBase,
+    AttendeeOrderSubFactory,
+    AttendeeSubFactory,
+)
 from tests.factories.event import EventFactoryBasic
-from tests.factories.event_invoice import EventInvoiceFactory
-from tests.factories.order import OrderFactory
+from tests.factories.event_invoice import EventInvoiceFactory, EventInvoiceSubFactory
+from tests.factories.order import OrderFactory, OrderSubFactory
 from tests.factories.ticket_fee import TicketFeesFactory
 from tests.factories.user import UserFactory
 
 
-class TestScheduledJobs(OpenEventLegacyTestCase):
-    def test_event_invoices_mark_due(self):
-        """Method to test marking of event invoices as due"""
+def test_delete_ticket_holder_created_currently(db):
+    """Method to test not deleting ticket holders with no order id but created within expiry time"""
+    attendee = AttendeeSubFactory(
+        created_at=datetime.datetime.utcnow(), modified_at=datetime.datetime.utcnow(),
+    )
+    db.session.commit()
 
-        with self.app.test_request_context():
-            event_invoice_new = EventInvoiceFactory(
-                event__ends_at=datetime.datetime(2019, 7, 20)
-            )
-            event_invoice_paid = EventInvoiceFactory(status="paid")
+    attendee_id = attendee.id
+    delete_ticket_holders_no_order_id()
+    ticket_holder = TicketHolder.query.get(attendee_id)
+    assert ticket_holder != None
 
-            db.session.commit()
 
-            event_invoice_new_id = event_invoice_new.id
-            event_invoice_paid_id = event_invoice_paid.id
+def test_delete_ticket_holder_with_valid_order_id(db):
+    """Method to test not deleting ticket holders with order id after expiry time"""
 
-            event_invoices_mark_due()
+    attendee = AttendeeOrderSubFactory(
+        created_at=datetime.datetime.utcnow() - datetime.timedelta(minutes=15),
+        modified_at=datetime.datetime.utcnow() - datetime.timedelta(minutes=15),
+    )
+    db.session.commit()
 
-            status_new = EventInvoice.query.get(event_invoice_new_id).status
-            status_paid = EventInvoice.query.get(event_invoice_paid_id).status
+    attendee_id = attendee.id
+    delete_ticket_holders_no_order_id()
+    ticket_holder = TicketHolder.query.get(attendee_id)
+    assert ticket_holder != None
 
-            self.assertEqual(status_new, "due")
-            self.assertNotEqual(status_paid, "due")
 
-    def test_delete_ticket_holders_with_no_order_id(self):
-        """Method to test deleting ticket holders with no order id after expiry time"""
+def test_delete_ticket_holders_with_no_order_id(db):
+    """Method to test deleting ticket holders with no order id after expiry time"""
+    attendee = AttendeeFactoryBase(created_at=common.date_)
+    db.session.commit()
+    attendee_id = attendee.id
+    delete_ticket_holders_no_order_id()
+    ticket_holder = TicketHolder.query.get(attendee_id)
+    assert ticket_holder == None
 
-        with self.app.test_request_context():
-            attendee = AttendeeFactory(created_at=common.date_)
-            db.session.commit()
-            attendee_id = attendee.id
-            delete_ticket_holders_no_order_id()
-            ticket_holder = TicketHolder.query.get(attendee_id)
-            self.assertIs(ticket_holder, None)
 
-    def test_delete_ticket_holder_created_currently(self):
-        """Method to test not deleting ticket holders with no order id but created within expiry time"""
+def test_event_invoices_mark_due(db):
+    """Method to test marking of event invoices as due"""
 
-        with self.app.test_request_context():
-            attendee = AttendeeFactory(
-                created_at=datetime.datetime.utcnow(),
-                modified_at=datetime.datetime.utcnow(),
-            )
+    event_invoice_new = EventInvoiceSubFactory(
+        event__ends_at=datetime.datetime(2019, 7, 20)
+    )
+    event_invoice_paid = EventInvoiceSubFactory(
+        status="paid", event=event_invoice_new.event
+    )
 
-            db.session.commit()
-            attendee_id = attendee.id
-            delete_ticket_holders_no_order_id()
-            ticket_holder = TicketHolder.query.get(attendee_id)
-            self.assertIsNot(ticket_holder, None)
+    db.session.commit()
 
-    def test_delete_ticket_holder_with_valid_order_id(self):
-        """Method to test not deleting ticket holders with order id after expiry time"""
+    event_invoice_new_id = event_invoice_new.id
+    event_invoice_paid_id = event_invoice_paid.id
 
-        with self.app.test_request_context():
-            attendee = AttendeeFactory(
-                order_id=1,
-                ticket_id=1,
-                created_at=datetime.datetime.utcnow() - datetime.timedelta(minutes=15),
-                modified_at=datetime.datetime.utcnow() - datetime.timedelta(minutes=15),
-            )
+    event_invoices_mark_due()
 
-            db.session.commit()
-            attendee_id = attendee.id
-            delete_ticket_holders_no_order_id()
-            ticket_holder = TicketHolder.query.get(attendee_id)
-            self.assertIsNot(ticket_holder, None)
+    status_new = EventInvoice.query.get(event_invoice_new_id).status
+    status_paid = EventInvoice.query.get(event_invoice_paid_id).status
 
-    def test_send_monthly_invoice(self):
-        """Method to test monthly invoices"""
+    assert status_new == "due"
+    assert status_paid == "paid"
 
-        with self.app.test_request_context():
-            TicketFeesFactory(service_fee=10.23, maximum_fee=11)
 
-            test_event = EventFactoryBasic(state='published')
+def test_send_monthly_invoice(db):
+    """Method to test monthly invoices"""
 
-            test_user = UserFactory()
+    TicketFeesFactory(service_fee=10.23, maximum_fee=11)
+    test_order = OrderSubFactory(
+        status='completed',
+        event__state='published',
+        completed_at=datetime.datetime.now() - datetime.timedelta(days=30),
+        amount=100,
+    )
+    test_ticket_holder = AttendeeSubFactory(event=test_order.event, order=test_order)
+    db.session.commit()
 
-            test_order = OrderFactory(status='completed')
-            test_order.completed_at = datetime.datetime.now() - datetime.timedelta(
-                days=30
-            )
-            test_order.amount = 100
-            test_order.event = test_event
+    send_monthly_event_invoice()
+    event_invoice = test_order.event.invoices[0]
+    assert event_invoice.amount == 10.23
 
-            test_ticket_holder = AttendeeFactory()
-            test_ticket_holder.event = test_event
-            test_ticket_holder.order = test_order
 
-            test_event.owner = test_user
-            db.session.commit()
+def test_expire_initializing_tickets(db):
+    order_expiry_time = get_settings()['order_expiry_time']
+    order_old = OrderSubFactory(
+        created_at=datetime.datetime.now(timezone.utc)
+        - timedelta(minutes=order_expiry_time)
+    )
+    attendees_old = AttendeeSubFactory.create_batch(3, order=order_old)
+    order_new = OrderSubFactory()
+    attendees_new = AttendeeSubFactory.create_batch(2, order=order_new)
+    db.session.commit()
 
-            send_monthly_event_invoice()
-            event_invoice = EventInvoice.query.get(1)
-            self.assertEqual(event_invoice.amount, 10.23)
+    expire_initializing_tickets()
+
+    assert order_old.status == 'expired'
+    assert len(order_old.ticket_holders) == 0
+    assert order_new.status == 'initializing'
+    assert len(order_new.ticket_holders) == 2
+
+
+def test_expire_pending_tickets(db):
+    order_old = OrderSubFactory(
+        status='pending',
+        created_at=datetime.datetime.now(timezone.utc) - timedelta(minutes=45),
+    )
+    attendees_old = AttendeeSubFactory.create_batch(3, order=order_old)
+    order_new = OrderSubFactory(
+        status='pending',
+        created_at=datetime.datetime.now(timezone.utc) - timedelta(minutes=15),
+    )
+    attendees_new = AttendeeSubFactory.create_batch(2, order=order_new)
+    db.session.commit()
+
+    expire_pending_tickets()
+
+    assert order_old.status == 'expired'
+    assert len(order_old.ticket_holders) == 3
+    assert order_new.status == 'pending'
+    assert len(order_new.ticket_holders) == 2

--- a/tests/factories/attendee.py
+++ b/tests/factories/attendee.py
@@ -3,7 +3,7 @@ import factory
 import tests.factories.common as common
 from tests.factories.base import BaseFactory
 from tests.factories.event import EventFactoryBasic
-from tests.factories.order import OrderFactory
+from tests.factories.order import OrderFactory, OrderSubFactory
 from tests.factories.ticket import TicketFactory
 from app.models.ticket_holder import TicketHolder
 
@@ -21,7 +21,6 @@ class AttendeeFactoryBase(BaseFactory):
     country = "IN"
     is_checked_in = True
     pdf_url = common.url_
-    event_id = 1
     ticket_id = None
     order_id = None
     modified_at = common.date_
@@ -31,7 +30,12 @@ class AttendeeSubFactory(AttendeeFactoryBase):
     event = factory.SubFactory(EventFactoryBasic)
 
 
+class AttendeeOrderSubFactory(AttendeeSubFactory):
+    order = factory.SubFactory(OrderSubFactory)
+
+
 class AttendeeFactory(AttendeeFactoryBase):
     event = factory.RelatedFactory(EventFactoryBasic)
     ticket = factory.RelatedFactory(TicketFactory)
     order = factory.RelatedFactory(OrderFactory)
+    event_id = 1

--- a/tests/factories/event_invoice.py
+++ b/tests/factories/event_invoice.py
@@ -8,13 +8,10 @@ from tests.factories.event import EventFactoryBasic
 from tests.factories.user import UserFactory
 
 
-class EventInvoiceFactory(BaseFactory):
+class EventInvoiceFactoryBase(BaseFactory):
     class Meta:
         model = EventInvoice
 
-    event = factory.RelatedFactory(EventFactoryBasic)
-    user = factory.RelatedFactory(UserFactory)
-    discount_code = factory.RelatedFactory(DiscountCodeFactory)
     amount = common.float_
     address = common.string_
     city = common.string_
@@ -30,6 +27,16 @@ class EventInvoiceFactory(BaseFactory):
     last4 = "1234"
     stripe_token = common.string_
     paypal_token = common.string_
+
+
+class EventInvoiceSubFactory(EventInvoiceFactoryBase):
+    event = factory.SubFactory(EventFactoryBasic)
+
+
+class EventInvoiceFactory(EventInvoiceFactoryBase):
+    event = factory.RelatedFactory(EventFactoryBasic)
+    user = factory.RelatedFactory(UserFactory)
+    discount_code = factory.RelatedFactory(DiscountCodeFactory)
     event_id = 1
     user_id = 2
     discount_code_id = 1


### PR DESCRIPTION
Currently, this is handled through Order List and Order GET API which is really bad. It should instead be handled through scheduled job like pending tickets are handled