### PR TITLE
feat: Make all order relationships read only

### DIFF
--- a/app/api/schema/orders.py
+++ b/app/api/schema/orders.py
@@ -116,6 +116,7 @@ class OrderSchema(SoftDeletionSchema):
         schema='AttendeeSchemaPublic',
         many=True,
         type_='attendee',
+        dump_only=True,
     )
 
     tickets = Relationship(
@@ -127,6 +128,7 @@ class OrderSchema(SoftDeletionSchema):
         schema='TicketSchemaPublic',
         many=True,
         type_="ticket",
+        dump_only=True,
     )
 
     user = Relationship(
@@ -137,6 +139,7 @@ class OrderSchema(SoftDeletionSchema):
         related_view_kwargs={'id': '<user_id>'},
         schema='UserSchemaPublic',
         type_="user",
+        dump_only=True,
     )
 
     event = Relationship(
@@ -147,6 +150,7 @@ class OrderSchema(SoftDeletionSchema):
         related_view_kwargs={'id': '<event_id>'},
         schema='EventSchemaPublic',
         type_="event",
+        dump_only=True,
     )
 
     event_invoice = Relationship(
@@ -157,6 +161,7 @@ class OrderSchema(SoftDeletionSchema):
         related_view_kwargs={'id': '<id>'},
         schema='EventInvoiceSchema',
         type_="event_invoice",
+        dump_only=True,
     )
 
     marketer = Relationship(
@@ -167,6 +172,7 @@ class OrderSchema(SoftDeletionSchema):
         related_view_kwargs={'id': '<marketer_id>'},
         schema='UserSchemaPublic',
         type_="user",
+        dump_only=True,
     )
 
     discount_code = Relationship(
@@ -177,4 +183,5 @@ class OrderSchema(SoftDeletionSchema):
         related_view_kwargs={'id': '<discount_code_id>'},
         schema='DiscountCodeSchemaPublic',
         type_="discount-code",
+        dump_only=True,
     )

--- a/tests/all/integration/api/helpers/order/test_edit_order.py
+++ b/tests/all/integration/api/helpers/order/test_edit_order.py
@@ -33,7 +33,7 @@ def test_throw_on_order_amount_update(client, db, user, jwt):
     )
 
 
-def test_throw_on_order_attendee_update(client, db, user, jwt):
+def test_ignore_on_order_attendee_update(client, db, user, jwt):
     order_id = create_order(db, user)
     attendee = AttendeeSubFactory()
     db.session.commit()
@@ -58,16 +58,14 @@ def test_throw_on_order_attendee_update(client, db, user, jwt):
     )
 
     order = Order.query.get(order_id)
-    assert response.status_code == 403
-    assert (
-        json.loads(response.data)['errors'][0]['detail']
-        == 'You cannot update ticket_holders of an order'
-    )
+    assert response.status_code == 200
     assert len(order.ticket_holders) == 3
 
 
-def test_throw_on_order_event_update(client, db, user, jwt):
+def test_ignore_on_order_event_update(client, db, user, jwt):
     order_id = create_order(db, user)
+    order = Order.query.get(order_id)
+    order_event = order.event
     event = EventFactoryBasic()
     db.session.commit()
 
@@ -90,8 +88,6 @@ def test_throw_on_order_event_update(client, db, user, jwt):
         data=data,
     )
 
-    assert response.status_code == 403
-    assert (
-        json.loads(response.data)['errors'][0]['detail']
-        == 'You cannot update event of an order'
-    )
+    db.session.refresh(order)
+    assert response.status_code == 200
+    assert order.event == order_event


### PR DESCRIPTION
There is absolutely no reason to allow changes in order relationships and those were previously disallowed via custom logic. But for some reason, SQLAlchemy was failing with `Unhashable type: 'dict'` when saving custom forms JSON in attendee (working) and then saving the order (throwing) either due to a bug in SQLAlchemy or flask-rest-jsonapi (more likely). So now, we have made order relationships read only so that none of the related items are saved needlessly on PATCH request