### PR TITLE
fix: Make event-invoices endpoint admin only

### DIFF
--- a/app/api/event_invoices.py
+++ b/app/api/event_invoices.py
@@ -41,7 +41,7 @@ class EventInvoiceList(ResourceList):
         :return:
         """
         user = current_user
-        if not user.is_admin and not user.is_super_admin:
+        if not user.is_staff:
             raise ForbiddenError({'source': ''}, 'Admin access is required')
 
         query_ = self.session.query(EventInvoice)

--- a/app/api/event_invoices.py
+++ b/app/api/event_invoices.py
@@ -55,7 +55,6 @@ class EventInvoiceList(ResourceList):
     methods = [
         'GET',
     ]
-    decorators = (api.has_permission('is_organizer',),)
     schema = EventInvoiceSchema
     data_layer = {
         'session': db.session,
@@ -81,7 +80,6 @@ class EventInvoiceDetail(ResourceDetail):
             )
             view_kwargs['id'] = event_invoice.id
 
-    decorators = (is_admin,)
     schema = EventInvoiceSchema
     data_layer = {
         'session': db.session,

--- a/app/api/event_invoices.py
+++ b/app/api/event_invoices.py
@@ -3,7 +3,6 @@ import datetime
 from flask import jsonify, request
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
 
-from app.api.bootstrap import api
 from app.api.helpers.db import safe_query, safe_query_kwargs, save_to_db
 from app.api.helpers.errors import BadRequestError
 from app.api.helpers.payment import PayPalPaymentsManager

--- a/app/api/helpers/permission_manager.py
+++ b/app/api/helpers/permission_manager.py
@@ -61,8 +61,9 @@ def is_organizer(view, view_args, view_kwargs, *args, **kwargs):
     if user.is_staff:
         return view(*view_args, **view_kwargs)
 
-    if user.is_owner(kwargs['event_id']) or user.is_organizer(kwargs['event_id']):
-        return view(*view_args, **view_kwargs)
+    if kwargs.get('event_id'):
+        if user.is_owner(kwargs['event_id']) or user.is_organizer(kwargs['event_id']):
+            return view(*view_args, **view_kwargs)
 
     raise ForbiddenError({'source': ''}, 'Organizer access is required')
 

--- a/app/api/helpers/permission_manager.py
+++ b/app/api/helpers/permission_manager.py
@@ -23,7 +23,8 @@ def auth_required(view, view_args, view_kwargs, *args, **kwargs):
 def is_super_admin(view, view_args, view_kwargs, *args, **kwargs):
     """
     Permission function for things allowed exclusively to super admin.
-    Do not use this if the resource is also accessible by a normal admin, use the is_admin decorator instead.
+    Do not use this if the resource is also accessible by a normal admin,
+    use the is_admin decorator instead.
     :return:
     """
     user = current_user
@@ -61,9 +62,9 @@ def is_organizer(view, view_args, view_kwargs, *args, **kwargs):
     if user.is_staff:
         return view(*view_args, **view_kwargs)
 
-    if kwargs.get('event_id'):
-        if user.is_owner(kwargs['event_id']) or user.is_organizer(kwargs['event_id']):
-            return view(*view_args, **view_kwargs)
+    event_id = kwargs.get('event_id')
+    if event_id and (user.is_owner(event_id) or user.is_organizer(event_id)):
+        return view(*view_args, **view_kwargs)
 
     raise ForbiddenError({'source': ''}, 'Organizer access is required')
 
@@ -95,7 +96,8 @@ def is_coorganizer_endpoint_related_to_event(
     view, view_args, view_kwargs, *args, **kwargs
 ):
     """
-     If the authorization header is present (but expired) and the event being accessed is not published
+     If the authorization header is present (but expired)
+     and the eventbeing accessed is not published
      - And the user is related to the event (organizer, co-organizer etc) show a 401
      - Else show a 404
 
@@ -381,7 +383,7 @@ def permission_manager(view, view_args, view_kwargs, *args, **kwargs):
     if 'id' in kwargs:
         view_kwargs['id'] = kwargs['id']
 
-    if 'methods' in kwargs:
+    if kwargs.get('methods'):
         methods = kwargs['methods']
 
     if request.method not in methods:
@@ -453,16 +455,16 @@ def permission_manager(view, view_args, view_kwargs, *args, **kwargs):
             fetch = kwargs['fetch']
             fetch_key_url = 'id'
             fetch_key_model = 'id'
-            if 'fetch_key_url' in kwargs:
+            if kwargs.get('fetch_key_url'):
                 fetch_key_url = kwargs['fetch_key_url']
 
-            if 'fetch_key_model' in kwargs:
+            if kwargs.get('fetch_key_model'):
                 fetch_key_model = kwargs['fetch_key_model']
 
             if not is_multiple(model):
                 model = [model]
 
-            if type(fetch_key_url) == str and is_multiple(fetch_key_url):
+            if isinstance(fetch_key_url, str) and is_multiple(fetch_key_url):
                 fetch_key_url = fetch_key_url.split(  # pytype: disable=attribute-error
                     ","
                 )
@@ -506,8 +508,7 @@ def permission_manager(view, view_args, view_kwargs, *args, **kwargs):
             raise NotFoundError({'source': ''}, 'Object not found.')
     if args[0] in permissions:
         return permissions[args[0]](view, view_args, view_kwargs, *args, **kwargs)
-    else:
-        raise ForbiddenError({'source': ''}, 'Access forbidden')
+    raise ForbiddenError({'source': ''}, 'Access forbidden')
 
 
 def has_access(access_level, **kwargs):


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #7063 

#### Short description of what this resolves:
Currently `/event-invoices` endpoint requires the `event_id` param in url or expects the user to be admin, which is not the case for this endpoint.

#### Changes proposed in this pull request:
Remove decorators `is_organizer` and `is_admin`.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.
