### PR TITLE
fix: Make attendee info editable only by admin or that user itself

### DIFF
--- a/app/api/attendees.py
+++ b/app/api/attendees.py
@@ -207,6 +207,12 @@ class AttendeeDetail(ResourceDetail):
         :return:
         """
         order = safe_query_by_id(Order, obj.order_id)
+
+        if not (current_user.is_staff or current_user.id == order.user_id):
+            raise ForbiddenError(
+                {'source': ''}, 'Only admin or that user itself can update attendee info',
+            )
+
         if order.status != 'initializing':
             raise UnprocessableEntityError(
                 {'pointer': '/data/id'},

--- a/app/api/attendees.py
+++ b/app/api/attendees.py
@@ -210,7 +210,7 @@ class AttendeeDetail(ResourceDetail):
 
         if not (current_user.is_staff or current_user.id == order.user_id):
             raise ForbiddenError(
-                {'source': ''}, 'Only admin or that user itself can update attendee info',
+                'Only admin or that user itself can update attendee info',
             )
 
         if order.status != 'initializing':

--- a/tests/all/integration/api/attendee/test_attendee_api.py
+++ b/tests/all/integration/api/attendee/test_attendee_api.py
@@ -6,17 +6,17 @@ from tests.factories.order import OrderSubFactory
 from tests.factories.ticket import TicketSubFactory
 
 
-def get_minimal_attendee(db):
+def get_minimal_attendee(db, user):
     attendee = AttendeeOrderTicketSubFactory(
-        email=None, address=None, city=None, state=None, country=None
+        email=None, address=None, city=None, state=None, country=None, order__user=user
     )
     db.session.commit()
 
     return attendee
 
 
-def test_edit_attendee_minimum_fields(db, client, jwt):
-    attendee = get_minimal_attendee(db)
+def test_edit_attendee_minimum_fields(db, client, jwt, user):
+    attendee = get_minimal_attendee(db, user)
 
     data = json.dumps(
         {
@@ -41,8 +41,8 @@ def test_edit_attendee_minimum_fields(db, client, jwt):
     assert attendee.lastname == 'Jamal'
 
 
-def get_simple_custom_form_attendee(db):
-    attendee = get_minimal_attendee(db)
+def get_simple_custom_form_attendee(db, user):
+    attendee = get_minimal_attendee(db, user)
     CustomForms(
         event=attendee.event,
         form='attendee',
@@ -64,8 +64,8 @@ def get_simple_custom_form_attendee(db):
     return attendee
 
 
-def test_edit_attendee_required_fields_missing(db, client, jwt):
-    attendee = get_simple_custom_form_attendee(db)
+def test_edit_attendee_required_fields_missing(db, client, jwt, user):
+    attendee = get_simple_custom_form_attendee(db, user)
 
     data = json.dumps(
         {
@@ -108,8 +108,8 @@ def test_edit_attendee_required_fields_missing(db, client, jwt):
     assert attendee.email is None
 
 
-def test_edit_attendee_required_fields_complete(db, client, jwt):
-    attendee = get_simple_custom_form_attendee(db)
+def test_edit_attendee_required_fields_complete(db, client, jwt, user):
+    attendee = get_simple_custom_form_attendee(db, user)
 
     data = json.dumps(
         {
@@ -147,8 +147,8 @@ def test_edit_attendee_required_fields_complete(db, client, jwt):
     assert attendee.complex_field_values is None
 
 
-def get_complex_custom_form_attendee(db):
-    attendee = get_minimal_attendee(db)
+def get_complex_custom_form_attendee(db, user):
+    attendee = get_minimal_attendee(db, user)
     CustomForms(
         event=attendee.event,
         form='attendee',
@@ -182,8 +182,8 @@ def get_complex_custom_form_attendee(db):
     return attendee
 
 
-def test_custom_form_complex_fields_missing_required(db, client, jwt):
-    attendee = get_complex_custom_form_attendee(db)
+def test_custom_form_complex_fields_missing_required(db, client, jwt, user):
+    attendee = get_complex_custom_form_attendee(db, user)
 
     data = json.dumps(
         {
@@ -222,8 +222,8 @@ def test_custom_form_complex_fields_missing_required(db, client, jwt):
     assert attendee.complex_field_values is None
 
 
-def test_custom_form_complex_fields_missing_required_one(db, client, jwt):
-    attendee = get_complex_custom_form_attendee(db)
+def test_custom_form_complex_fields_missing_required_one(db, client, jwt, user):
+    attendee = get_complex_custom_form_attendee(db, user)
 
     data = json.dumps(
         {
@@ -267,8 +267,8 @@ def test_custom_form_complex_fields_missing_required_one(db, client, jwt):
     assert attendee.complex_field_values is None
 
 
-def test_custom_form_complex_fields_complete(db, client, jwt):
-    attendee = get_complex_custom_form_attendee(db)
+def test_custom_form_complex_fields_complete(db, client, jwt, user):
+    attendee = get_complex_custom_form_attendee(db, user)
 
     data = json.dumps(
         {
@@ -302,9 +302,9 @@ def test_custom_form_complex_fields_complete(db, client, jwt):
     assert attendee.complex_field_values['best_friend'] == 'Tester'
 
 
-def test_ignore_complex_custom_form_fields(db, client, jwt):
+def test_ignore_complex_custom_form_fields(db, client, jwt, user):
     """Test to see that extra data from complex JSON is dropped"""
-    attendee = get_complex_custom_form_attendee(db)
+    attendee = get_complex_custom_form_attendee(db, user)
 
     data = json.dumps(
         {
@@ -344,8 +344,8 @@ def test_ignore_complex_custom_form_fields(db, client, jwt):
     assert attendee.complex_field_values.get('shalimar') is None
 
 
-def test_throw_complex_custom_form_fields(db, client, jwt):
-    attendee = get_complex_custom_form_attendee(db)
+def test_throw_complex_custom_form_fields(db, client, jwt, user):
+    attendee = get_complex_custom_form_attendee(db, user)
     CustomForms(
         event=attendee.event,
         form='attendee',
@@ -400,8 +400,8 @@ def test_throw_complex_custom_form_fields(db, client, jwt):
     }
 
 
-def test_throw_invalid_complex_custom_form_fields(db, client, jwt):
-    attendee = get_complex_custom_form_attendee(db)
+def test_throw_invalid_complex_custom_form_fields(db, client, jwt, user):
+    attendee = get_complex_custom_form_attendee(db, user)
     CustomForms(
         event=attendee.event,
         form='attendee',
@@ -522,8 +522,8 @@ def test_edit_attendee_order(db, client, jwt):
     assert attendee.order.id == attendee_order.id
 
 
-def test_edit_attendee_when_order_is_pending(db, client, jwt):
-    attendee = AttendeeOrderTicketSubFactory()
+def test_edit_attendee_when_order_is_pending(db, client, jwt, user):
+    attendee = AttendeeOrderTicketSubFactory(order__user=user)
     order = attendee.order
 
     order.status = "pending"
@@ -557,8 +557,8 @@ def test_edit_attendee_when_order_is_pending(db, client, jwt):
     assert attendee.lastname != "Ali"
 
 
-def test_edit_attendee_when_order_is_completed(db, client, jwt):
-    attendee = AttendeeOrderTicketSubFactory()
+def test_edit_attendee_when_order_is_completed(db, client, jwt, user):
+    attendee = AttendeeOrderTicketSubFactory(order__user=user)
     order = attendee.order
 
     order.status = "completed"


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #7104 

#### Short description of what this resolves:
Right now anybody can edit attendee info which is not correct.

#### Changes proposed in this pull request:
Only admin or that user itself should be able to edit attendee's info.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.
