### PR TITLE
fix: Fail order status transition to pending if incomplete attendee info

### DIFF
--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -381,7 +381,7 @@ class OrderDetail(ResourceDetail):
         :param view_kwargs:
         :return:
         """
-        if data.get('status') == 'pending':
+        if data.get('status') in ['pending', 'placed', 'completed']:
             attendees = order.ticket_holders
             for attendee in attendees:
                 validate_custom_form_constraints_request(

--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -12,6 +12,7 @@ from marshmallow_jsonapi import fields
 from marshmallow_jsonapi.flask import Schema
 
 from app.api.bootstrap import api
+from app.api.helpers.custom_forms import validate_custom_form_constraints_request
 from app.api.data_layers.ChargesLayer import ChargesLayer
 from app.api.helpers.db import safe_query, safe_query_by_id, safe_query_kwargs, save_to_db
 from app.api.helpers.errors import (
@@ -46,6 +47,7 @@ from app.api.helpers.storage import UPLOAD_PATHS, generate_hash
 from app.api.helpers.ticketing import validate_discount_code, validate_ticket_holders
 from app.api.helpers.utilities import dasherize, require_relationship
 from app.api.schema.orders import OrderSchema
+from app.api.schema.attendees import AttendeeSchema
 from app.models import db
 from app.models.order import Order, OrderTicket, get_updatable_fields
 from app.models.ticket_holder import TicketHolder
@@ -379,6 +381,13 @@ class OrderDetail(ResourceDetail):
         :param view_kwargs:
         :return:
         """
+        if data.get('status') == 'pending':
+            attendees = order.ticket_holders
+            for attendee in attendees:
+                validate_custom_form_constraints_request(
+                    'attendee', AttendeeSchema, attendee, {}
+                )
+
         if data.get('amount') and (
             data.get('is_billing_enabled') or order.event.is_billing_info_mandatory
         ):

--- a/tests/all/integration/api/helpers/order/test_edit_order.py
+++ b/tests/all/integration/api/helpers/order/test_edit_order.py
@@ -1,6 +1,7 @@
 import json
 
 from app.models.order import Order
+from app.models.custom_form import CustomForms
 from tests.factories.attendee import AttendeeSubFactory
 from tests.factories.event import EventFactoryBasic
 from tests.factories.order import OrderSubFactory
@@ -91,3 +92,150 @@ def test_ignore_on_order_event_update(client, db, user, jwt):
     db.session.refresh(order)
     assert response.status_code == 200
     assert order.event == order_event
+
+
+def get_simple_custom_form_order(db, user):
+    order = OrderSubFactory(amount=234, status='initializing', user=user)
+    attendee = AttendeeSubFactory(order=order)
+
+    CustomForms(
+        event=attendee.event,
+        form='attendee',
+        field_identifier='jobTitle',
+        type='text',
+        is_included=True,
+        is_required=True,
+    )
+
+    CustomForms(
+        event=attendee.event,
+        form='attendee',
+        field_identifier='taxBusinessInfo',
+        type='text',
+        is_included=True,
+        is_required=True,
+    )
+
+    db.session.commit()
+
+    return str(order.id)
+
+
+def get_complex_custom_form_order(db, user):
+    order = OrderSubFactory(amount=234, status='initializing', user=user)
+    attendee = AttendeeSubFactory(order=order)
+
+    CustomForms(
+        event=attendee.event,
+        form='attendee',
+        field_identifier='whatUniversity',
+        name='what university',
+        type='text',
+        is_complex=True,
+        is_included=True,
+        is_required=True,
+    )
+
+    CustomForms(
+        event=attendee.event,
+        form='attendee',
+        field_identifier='whatCollege',
+        name='what college',
+        type='text',
+        is_complex=True,
+        is_included=True,
+        is_required=True,
+    )
+
+    CustomForms(
+        event=attendee.event,
+        form='attendee',
+        field_identifier='naamBatao',
+        name='naam batao',
+        type='text',
+        is_complex=True,
+        is_included=True,
+        is_required=False,
+    )
+
+    db.session.commit()
+
+    return str(order.id)
+
+
+def test_order_status_to_pending_incomplete_simple_custom_form(client, db, user, jwt):
+    order_id = get_simple_custom_form_order(db, user)
+    order = Order.query.get(order_id)
+
+    data = json.dumps(
+        {
+            "data": {
+                "attributes": {"status": "pending", "order-notes": "take me to pending"},
+                "type": "order",
+                "id": order_id,
+            }
+        }
+    )
+
+    response = client.patch(
+        f'/v1/orders/{order_id}',
+        content_type='application/vnd.api+json',
+        headers=jwt,
+        data=data,
+    )
+
+    db.session.refresh(order)
+
+    assert response.status_code == 422
+    assert order.status != "pending"
+    assert order.order_notes != "take me to pending"
+    assert json.loads(response.data) == {
+        'errors': [
+            {
+                'status': 422,
+                'source': {'pointer': '/data/attributes'},
+                'title': 'Unprocessable Entity',
+                'detail': "Missing required fields ['job_title', 'tax_business_info']",
+            }
+        ],
+        'jsonapi': {'version': '1.0'},
+    }
+
+
+def test_order_status_to_pending_incomplete_complex_custom_form(client, db, user, jwt):
+    order_id = get_complex_custom_form_order(db, user)
+    order = Order.query.get(order_id)
+
+    data = json.dumps(
+        {
+            "data": {
+                "attributes": {"status": "pending", "order-notes": "do it pending"},
+                "type": "order",
+                "id": order_id,
+            }
+        }
+    )
+
+    response = client.patch(
+        f'/v1/orders/{order_id}',
+        content_type='application/vnd.api+json',
+        headers=jwt,
+        data=data,
+    )
+
+    db.session.refresh(order)
+
+    assert response.status_code == 422
+    assert order.status != "pending"
+    assert order.order_notes != "do it pending"
+    assert json.loads(response.data) == {
+        'errors': [
+            {
+                'status': 422,
+                'source': {'pointer': '/data/attributes'},
+                'title': 'Unprocessable Entity',
+                'detail': "Missing required fields ['what_college', 'what_university']",
+            }
+        ],
+        'jsonapi': {'version': '1.0'},
+    }

--- a/tests/all/integration/api/helpers/order/test_edit_order.py
+++ b/tests/all/integration/api/helpers/order/test_edit_order.py
@@ -163,7 +163,7 @@ def get_complex_custom_form_order(db, user):
     return str(order.id)
 
 
-def test_order_status_to_pending_incomplete_simple_custom_form(client, db, user, jwt):
+def test_order_pending_incomplete_simple_custom_form(client, db, user, jwt):
     order_id = get_simple_custom_form_order(db, user)
     order = Order.query.get(order_id)
 
@@ -202,7 +202,7 @@ def test_order_status_to_pending_incomplete_simple_custom_form(client, db, user,
     }
 
 
-def test_order_status_to_pending_incomplete_complex_custom_form(client, db, user, jwt):
+def test_order_pending_incomplete_complex_custom_form(client, db, user, jwt):
     order_id = get_complex_custom_form_order(db, user)
     order = Order.query.get(order_id)
 

--- a/tests/all/integration/api/helpers/order/test_edit_order.py
+++ b/tests/all/integration/api/helpers/order/test_edit_order.py
@@ -94,33 +94,6 @@ def test_ignore_on_order_event_update(client, db, user, jwt):
     assert order.event == order_event
 
 
-def get_simple_custom_form_order(db, user):
-    order = OrderSubFactory(amount=234, status='initializing', user=user)
-    attendee = AttendeeSubFactory(order=order)
-
-    CustomForms(
-        event=attendee.event,
-        form='attendee',
-        field_identifier='jobTitle',
-        type='text',
-        is_included=True,
-        is_required=True,
-    )
-
-    CustomForms(
-        event=attendee.event,
-        form='attendee',
-        field_identifier='taxBusinessInfo',
-        type='text',
-        is_included=True,
-        is_required=True,
-    )
-
-    db.session.commit()
-
-    return str(order.id)
-
-
 def get_complex_custom_form_order(db, user):
     order = OrderSubFactory(amount=234, status='initializing', user=user)
     attendee = AttendeeSubFactory(order=order)
@@ -163,45 +136,6 @@ def get_complex_custom_form_order(db, user):
     return str(order.id)
 
 
-def test_order_pending_incomplete_simple_custom_form(client, db, user, jwt):
-    order_id = get_simple_custom_form_order(db, user)
-    order = Order.query.get(order_id)
-
-    data = json.dumps(
-        {
-            "data": {
-                "attributes": {"status": "pending", "order-notes": "take me to pending"},
-                "type": "order",
-                "id": order_id,
-            }
-        }
-    )
-
-    response = client.patch(
-        f'/v1/orders/{order_id}',
-        content_type='application/vnd.api+json',
-        headers=jwt,
-        data=data,
-    )
-
-    db.session.refresh(order)
-
-    assert response.status_code == 422
-    assert order.status != "pending"
-    assert order.order_notes != "take me to pending"
-    assert json.loads(response.data) == {
-        'errors': [
-            {
-                'status': 422,
-                'source': {'pointer': '/data/attributes'},
-                'title': 'Unprocessable Entity',
-                'detail': "Missing required fields ['job_title', 'tax_business_info']",
-            }
-        ],
-        'jsonapi': {'version': '1.0'},
-    }
-
-
 def test_order_pending_incomplete_complex_custom_form(client, db, user, jwt):
     order_id = get_complex_custom_form_order(db, user)
     order = Order.query.get(order_id)
@@ -228,6 +162,45 @@ def test_order_pending_incomplete_complex_custom_form(client, db, user, jwt):
     assert response.status_code == 422
     assert order.status != "pending"
     assert order.order_notes != "do it pending"
+    assert json.loads(response.data) == {
+        'errors': [
+            {
+                'status': 422,
+                'source': {'pointer': '/data/attributes'},
+                'title': 'Unprocessable Entity',
+                'detail': "Missing required fields ['what_college', 'what_university']",
+            }
+        ],
+        'jsonapi': {'version': '1.0'},
+    }
+
+
+def test_order_placed_incomplete_complex_custom_form(client, db, user, jwt):
+    order_id = get_complex_custom_form_order(db, user)
+    order = Order.query.get(order_id)
+
+    data = json.dumps(
+        {
+            "data": {
+                "attributes": {"status": "placed", "order-notes": "just place it"},
+                "type": "order",
+                "id": order_id,
+            }
+        }
+    )
+
+    response = client.patch(
+        f'/v1/orders/{order_id}',
+        content_type='application/vnd.api+json',
+        headers=jwt,
+        data=data,
+    )
+
+    db.session.refresh(order)
+
+    assert response.status_code == 422
+    assert order.status != "placed"
+    assert order.order_notes != "just place it"
     assert json.loads(response.data) == {
         'errors': [
             {


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #7069 

#### Short description of what this resolves:
Right now order status can be transitioned to `pending` even if corresponding attendees have incomplete info, which is incorrect.

#### Changes proposed in this pull request:
Fail order status transitioning to `pending` if incomplete attendee info 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.
