### PR TITLE
fix: Make user relationship in speaker schema dump_only

### DIFF
--- a/app/api/schema/speakers.py
+++ b/app/api/schema/speakers.py
@@ -73,6 +73,7 @@ class SpeakerSchema(SoftDeletionSchema):
         related_view_kwargs={'speaker_id': '<id>'},
         schema='UserSchemaPublic',
         type_='user',
+        dump_only=True,
     )
     sessions = Relationship(
         attribute='sessions',

--- a/app/api/speakers.py
+++ b/app/api/speakers.py
@@ -172,6 +172,9 @@ class SpeakerDetail(ResourceDetail):
         :param view_kwargs:
         :return:
         """
+        if not current_user.is_staff:
+            data['user'] = current_user.id
+
         if not can_edit_after_cfs_ends(speaker.event_id):
             raise ForbiddenError(
                 {'source': ''}, "Cannot edit speaker after the call for speaker is ended"

--- a/app/api/speakers.py
+++ b/app/api/speakers.py
@@ -172,9 +172,6 @@ class SpeakerDetail(ResourceDetail):
         :param view_kwargs:
         :return:
         """
-        if not current_user.is_staff:
-            data['user'] = current_user.id
-
         if not can_edit_after_cfs_ends(speaker.event_id):
             raise ForbiddenError(
                 {'source': ''}, "Cannot edit speaker after the call for speaker is ended"


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #7106 

#### Short description of what this resolves:
Speaker schema can receive user relationship which is not needed for POST and PATCH

#### Changes proposed in this pull request:
Make user relationship in speaker schema `dump_only` and instead assign current user's id to user relationship.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.
