### PR TITLE
fix: Send after event emails and notifs to unique receivers

### DIFF
--- a/app/api/helpers/scheduled_jobs.py
+++ b/app/api/helpers/scheduled_jobs.py
@@ -53,18 +53,19 @@ def send_after_event_mail():
             )
             frontend_url = get_settings()['frontend_url']
             if current_time > event.ends_at and time_difference_minutes < 1440:
+                unique_emails = set()
                 for speaker in speakers:
                     if not speaker.is_email_overridden:
-                        send_email_after_event(
-                            speaker.user.email, event.name, frontend_url
-                        )
+                        unique_emails.add(speaker.user.email)
                         send_notif_after_event(speaker.user, event.name)
                 for organizer in organizers:
-                    send_email_after_event(organizer.user.email, event.name, frontend_url)
+                    unique_emails.add(organizer.user.email)
                     send_notif_after_event(organizer.user, event.name)
                 if owner:
-                    send_email_after_event(owner.user.email, event.name, frontend_url)
+                    unique_emails.add(owner.user.email)
                     send_notif_after_event(owner.user, event.name)
+                for email in unique_emails:
+                    send_email_after_event(email, event.name, frontend_url)
 
 
 @celery.task(base=RequestContextTask, name='change.session.state.on.event.completion')

--- a/app/api/helpers/scheduled_jobs.py
+++ b/app/api/helpers/scheduled_jobs.py
@@ -54,7 +54,7 @@ def send_after_event_mail():
             frontend_url = get_settings()['frontend_url']
             if current_time > event.ends_at and time_difference_minutes < 1440:
                 unique_emails = set()
-                user_objects = list()
+                user_objects = []
                 for speaker in speakers:
                     if not speaker.is_email_overridden:
                         unique_emails.add(speaker.user.email)

--- a/app/api/helpers/utilities.py
+++ b/app/api/helpers/utilities.py
@@ -13,6 +13,19 @@ from itsdangerous import Serializer
 from app.api.helpers.errors import UnprocessableEntityError
 
 
+def make_dict(list_of_object, key):
+    """
+    To convert a list of object into dict.
+
+    This will return a dict containing unique keys
+    mapped to the object which contains that key.
+    """
+    mapped_dict = dict()
+    for obj in list_of_object:
+        mapped_dict[getattr(obj, key)] = obj
+    return mapped_dict
+
+
 def dasherize(text):
     return text.replace('_', '-')
 

--- a/app/api/helpers/utilities.py
+++ b/app/api/helpers/utilities.py
@@ -20,7 +20,7 @@ def make_dict(list_of_object, key):
     This will return a dict containing unique keys
     mapped to the object which contains that key.
     """
-    mapped_dict = dict()
+    mapped_dict = {}
     for obj in list_of_object:
         mapped_dict[getattr(obj, key)] = obj
     return mapped_dict


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #6731 

#### Short description of what this resolves:
Multiple emails can be sent if the same user is owner, speaker or organizer which is wrong. Only single email should be sent in that case.

#### Changes proposed in this pull request:
Send after event emails to unique email ids only by creating a `set` of unique emails.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.
