### PR TITLE
fix: Send email when change in session state

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -280,14 +280,9 @@ class SessionDetail(ResourceDetail):
         )
 
     def after_update_object(self, session, data, view_kwargs):
-        """ Send email if session accepted or rejected """
+        """ Send email if session state changes """
 
-        if (
-            'state' in data
-            and data.get('send_email', None)
-            and (session.state == 'accepted' or session.state == 'rejected')
-        ):
-
+        if 'state' in data and data.get('send_email', None):
             event = session.event
             # Email for speaker
             speakers = session.speakers

--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -257,14 +257,9 @@ class SessionDetail(ResourceDetail):
 
         new_state = data.get('state')
 
-        g.send_email = (
-            new_state is not None
-            and new_state != session.state
-            and (new_state == 'accepted' or new_state == 'rejected')
-        )
-
         if new_state and new_state != session.state:
             # State change detected. Verify that state change is allowed
+            g.send_email = new_state == 'accepted' or new_state == 'rejected'
             key = 'speaker'
             if is_organizer:
                 key = 'organizer'
@@ -289,7 +284,7 @@ class SessionDetail(ResourceDetail):
     def after_update_object(self, session, data, view_kwargs):
         """ Send email if session accepted or rejected """
 
-        if g.send_email:
+        if data.get('send_email', None) and g.get('send_email'):
             event = session.event
             # Email for speaker
             speakers = session.speakers


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #7155 

#### Short description of what this resolves:
Email was being sent only when the final session state is accepted or rejected.

#### Changes proposed in this pull request:
Send email when there's a change in session state.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.
