### PR TITLE
chore(docs): Fix broken link to API description

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,14 @@ When checking in code for models, please update migrations as well.
 
 ### API documentation
 
-The api is documented using [api blueprint](https://apiblueprint.org/). Local changes to [the description](https://github.com/fossasia/open-event-server/blob/development/docs/api/api_blueprint.apib) can be viewed using e.g. the [apiary gem](https://help.apiary.io/tools/apiary-cli/):
+The api is documented using [api blueprint](https://apiblueprint.org/). First, generate the description/blueprint `.apib` file using:
+
+```bash
+npx aglio --input docs/api/api_blueprint_source.apib --compile --output docs/api/api_blueprint.apib # generate the description .apib file
+
+```
+
+Local changes to [the description](https://github.com/fossasia/open-event-server/blob/development/docs/api/api_blueprint.apib) can be viewed using e.g. the [apiary gem](https://help.apiary.io/tools/apiary-cli/):
 
 ```bash
 gem install apiaryio # dependency

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ npx aglio --input docs/api/api_blueprint_source.apib --compile --output docs/api
 
 ```
 
-Local changes to [the description](https://github.com/fossasia/open-event-server/blob/development/docs/api/api_blueprint.apib) can be viewed using e.g. the [apiary gem](https://help.apiary.io/tools/apiary-cli/):
+Local changes to the description can be viewed using e.g. the [apiary gem](https://help.apiary.io/tools/apiary-cli/):
 
 ```bash
 gem install apiaryio # dependency


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #7213 

#### Short description of what this resolves:
Added the command to generate the file to view api description/blueprint in the docs

#### Changes proposed in this pull request:

-
-
-

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.
