### PR TITLE
chore: Make celery container depend on web

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,8 @@ services:
   celery:
     <<: *defaults
     container_name: opev-celery
+    depends_on:
+      - web
     environment:
       <<: *environment-vars
       C_FORCE_ROOT: "true"


### PR DESCRIPTION
Celery gets restarted with web on code changes and runs before migrations are complete. This results in table/column not found errors. It depending on web will mean that it won't run until the migrations are run and server has started. It does add unnecessary coupling between celery and web container but it is the easiest way to ensure this without creating locking issues