### PR TITLE
feat: Allow user verification through API request

### DIFF
--- a/app/api/schema/users.py
+++ b/app/api/schema/users.py
@@ -67,7 +67,7 @@ class UserSchema(UserSchemaPublic):
     is_user_moderator = fields.Boolean(dump_only=True)
     is_user_registrar = fields.Boolean(dump_only=True)
     is_user_attendee = fields.Boolean(dump_only=True)
-    is_verified = fields.Boolean(dump_only=True)
+    is_verified = fields.Boolean()
     last_accessed_at = fields.DateTime(dump_only=True)
     created_at = fields.DateTime(dump_only=True)
     deleted_at = fields.DateTime(dump_only=True)

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -67,9 +67,10 @@ class UserList(ResourceList):
                 {'pointer': '/data/attributes/email'}, "Email already exists"
             )
 
-        if data.get('is_verified') is not None:
+        if data.get('is_verified'):
             raise UnprocessableEntityError(
-                {'pointer': '/data/attributes/is_verified'}, "You are not allowed to submit this field"
+                {'pointer': '/data/attributes/is_verified'},
+                "You are not allowed to submit this field"
             )
 
     def after_create_object(self, user, data, view_kwargs):
@@ -289,9 +290,9 @@ class UserDetail(ResourceDetail):
                     {'source': ''}, "You are not authorized to update this information."
                 )
 
-        if not has_access('is_admin') and data.get('is_verified') is not None:
+        if not has_access('is_admin') and data.get('is_verified') != user.is_verified:
             raise ForbiddenError(
-                {'pointer': '/data/attributes/is_verified'}, 
+                {'pointer': '/data/attributes/is_verified'},
                 "Admin access is required to update this information."
             )
 

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -69,7 +69,7 @@ class UserList(ResourceList):
 
         if data.get('is_verified'):
             raise UnprocessableEntityError(
-                {'pointer': '/data/attributes/is_verified'},
+                {'pointer': '/data/attributes/is-verified'},
                 "You are not allowed to submit this field"
             )
 
@@ -296,7 +296,7 @@ class UserDetail(ResourceDetail):
             and data.get('is_verified') != user.is_verified
         ):
             raise ForbiddenError(
-                {'pointer': '/data/attributes/is_verified'},
+                {'pointer': '/data/attributes/is-verified'},
                 "Admin access is required to update this information."
             )
 

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -290,7 +290,11 @@ class UserDetail(ResourceDetail):
                     {'source': ''}, "You are not authorized to update this information."
                 )
 
-        if not has_access('is_admin') and data.get('is_verified') != user.is_verified:
+        if (
+            not has_access('is_admin')
+            and data.get('is_verified') is not None
+            and data.get('is_verified') != user.is_verified
+        ):
             raise ForbiddenError(
                 {'pointer': '/data/attributes/is_verified'},
                 "Admin access is required to update this information."

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -67,6 +67,11 @@ class UserList(ResourceList):
                 {'pointer': '/data/attributes/email'}, "Email already exists"
             )
 
+        if data.get('is_verified') is not None:
+            raise UnprocessableEntityError(
+                {'pointer': '/data/attributes/is_verified'}, "You are not allowed to submit this field"
+            )
+
     def after_create_object(self, user, data, view_kwargs):
         """
         method to send-
@@ -283,6 +288,12 @@ class UserDetail(ResourceDetail):
                 raise ForbiddenError(
                     {'source': ''}, "You are not authorized to update this information."
                 )
+
+        if not has_access('is_admin') and data.get('is_verified') is not None:
+            raise ForbiddenError(
+                {'pointer': '/data/attributes/is_verified'}, 
+                "Admin access is required to update this information."
+            )
 
         users_email = data.get('email', None)
         if users_email is not None:


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #7278

#### Short description of what this resolves:
Allows admins to verify users through API request

#### Changes proposed in this pull request:

- Remove is_verified field from being read-only
- Add conditions to raise errors if anyone tries to post this field and if anyone other than admin tries to update this field

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [X] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [X] All the functions created/modified in this PR contain relevant docstrings.
