### PR TITLE
fix: Configure paypal on charge request

### DIFF
--- a/app/api/helpers/payment.py
+++ b/app/api/helpers/payment.py
@@ -179,8 +179,7 @@ class PayPalPaymentsManager:
                 {'pointer': ''},
                 "Payments through Paypal have not been configured on the platform",
             )
-
-        paypalrestsdk.configure(
+        return paypalrestsdk.configure(
             {
                 "mode": paypal_mode,
                 "client_id": paypal_client,
@@ -284,7 +283,7 @@ class PayPalPaymentsManager:
         :param paypal_payer_id: payer_id
         :return: Result of the transaction.
         """
-
+        PayPalPaymentsManager.configure_paypal()
         payment = paypalrestsdk.Payment.find(paypal_payment_id)
 
         if payment.execute({"payer_id": paypal_payer_id}):


### PR DESCRIPTION
Fixes #6872 

The charge function was missing the paypal configure method call. And so, in case payment create and charge requests were handled by the same worker, then everything worked correctly since the configuration was done on the payment creation call, so the worker got configured for the charge request. But in case, charge request was handled by a new worker which did not create the payment, it would be uninitialized with the config, hence throw the error. This was fixed by using environment variables as they are global