### PR TITLE
chore: Configure pre-commit for excluding files through black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,10 @@ repos:
     rev: stable
     hooks:
     - id: black
+      exclude:
+      - .venv/
+      - migrations/
+      - manage.py
+      - instance.py
+      - hook_main.py
       language_version: python3.7


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #7097 

#### Short description of what this resolves:
I hard-coded the files/folders that needs to be excluded in the pre-commit config file. Now, when you run `black -v .` black ignores the excluded folders/files.
