### PR TITLE
chore(docs): Correct name of Postgres "peer" authentication method

### DIFF
--- a/docs/installation/local.md
+++ b/docs/installation/local.md
@@ -106,7 +106,7 @@ createdb oevent -O $USER
 createdb opev_test -O $USER
 ```
 
-This method is called "ident" method, where the connection is established via "Unix domain socket", which is a file, instead of a pair of IP:port. This method is safe because:
+This method is called "peer" method, where the connection is established via "Unix domain socket", which is a file, instead of a pair of `IP:port`. This method is safe because:
 
 - No password to protect.
 - Only available to same-machine clients, meaning no worries about attack from outside.


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #

#### Short description of what this resolves:

I incorrectly called Postgres "peer" authentication method as "ident". This PR is to fix that.

#### Changes proposed in this pull request:

- Change "ident" to "peer" in installation doc.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
