### PR TITLE
fix: Restrict event query API

### DIFF
--- a/app/api/access_codes.py
+++ b/app/api/access_codes.py
@@ -85,7 +85,7 @@ class AccessCodeList(ResourceList):
         :return:
         """
         query_ = self.session.query(AccessCode)
-        query_ = event_query(query_, view_kwargs, permission='is_coorganizer')
+        query_ = event_query(query_, view_kwargs, restrict=True)
         if view_kwargs.get('user_id'):
             user = safe_query_kwargs(User, view_kwargs, 'user_id')
             if not has_access('is_user_itself', user_id=user.id):

--- a/app/api/attendees.py
+++ b/app/api/attendees.py
@@ -158,7 +158,7 @@ class AttendeeList(ResourceList):
                 User.id == user.id
             )
 
-        query_ = event_query(query_, view_kwargs, permission='is_registrar')
+        query_ = event_query(query_, view_kwargs, restrict=True)
         return query_
 
     view_kwargs = True

--- a/app/api/event_invoices.py
+++ b/app/api/event_invoices.py
@@ -34,7 +34,7 @@ class EventInvoiceList(ResourceList):
             raise ForbiddenError({'source': ''}, 'Admin access is required')
 
         query_ = self.session.query(EventInvoice)
-        query_ = event_query(query_, view_kwargs)
+        query_ = event_query(query_, view_kwargs, restrict=True)
         if user_id:
             user = safe_query_kwargs(User, view_kwargs, 'user_id')
             query_ = query_.join(User).filter(User.id == user.id)

--- a/app/api/helpers/permission_manager.py
+++ b/app/api/helpers/permission_manager.py
@@ -2,7 +2,6 @@ from typing import Union
 
 from flask import request
 from flask_jwt_extended import current_user, verify_jwt_in_request
-from flask_jwt_extended.utils import get_jwt_identity
 from sqlalchemy.orm.exc import NoResultFound
 
 from app.api.helpers.errors import ForbiddenError, NotFoundError
@@ -13,7 +12,6 @@ from app.models.event_invoice import EventInvoice
 from app.models.order import Order
 from app.models.session import Session
 from app.models.speaker import Speaker
-from app.models.user import User
 
 
 @jwt_required
@@ -536,11 +534,4 @@ def has_access(access_level, **kwargs):
 
 
 def is_logged_in() -> bool:
-    return get_auth_user() is not None
-
-
-def get_auth_user() -> Union[None, User]:
-    if 'Authorization' in request.headers:
-        verify_jwt_in_request()
-        return get_jwt_identity()
-    return None
+    return 'Authorization' in request.headers

--- a/app/api/helpers/query.py
+++ b/app/api/helpers/query.py
@@ -1,8 +1,8 @@
-from flask import request
 from flask_rest_jsonapi.exceptions import ObjectNotFound
 
 from app.api.helpers.db import safe_query_kwargs
-from app.api.helpers.permission_manager import has_access
+from app.api.helpers.errors import ForbiddenError
+from app.api.helpers.permission_manager import has_access, is_logged_in
 from app.models.event import Event
 from app.models.role import Role
 from app.models.users_events_role import UsersEventsRoles
@@ -13,11 +13,22 @@ def event_query(
     view_kwargs,
     event_id='event_id',
     event_identifier='event_identifier',
-    permission='is_coorganizer_endpoint_related_to_event',
+    permission=None,
+    restrict=False,
 ):
     """
     Queries the event according to 'event_id' and 'event_identifier' and joins for the query
-    For draft events, if the user is not logged in or does not have required permissions, a 404 is raised
+    For draft events, a 404 is raised
+    If the user is not logged in or does not have required permissions, 403 is raised
+
+    For a draft event, unless the user is organizer+ or has access to the passed permission,
+    404 will always be raised, regardless of restrict being True or not.
+
+    For a published event, if restrict is False, the query will allowed.
+
+    If restrict is True, then the passed permission or co-organizer access will be enforced.
+    If the permission passes, query will be allowed, otherwise, a 403 will be thrown
+
     :param event_id: String representing event_id in the view_kwargs
     :param event_identifier: String representing event_identifier in the view_kwargs
     :param query_: Query object
@@ -25,26 +36,25 @@ def event_query(
     :param permission: the name of the permission to be applied as a string. Default: is_coorganizer
     :return:
     """
+    permission = permission or 'is_coorganizer_endpoint_related_to_event'
+
+    event = None
     if view_kwargs.get(event_id):
         event = safe_query_kwargs(Event, view_kwargs, event_id)
-        if event.state != 'published' and (
-            'Authorization' not in request.headers
-            or not has_access(permission, event_id=event.id)
-        ):
-            raise ObjectNotFound(
-                {'parameter': event_id},
-                "Event: {} not found".format(view_kwargs[event_id]),
-            )
-        query_ = query_.join(Event).filter(Event.id == event.id)
     elif view_kwargs.get(event_identifier):
         event = safe_query_kwargs(Event, view_kwargs, event_identifier, 'identifier')
-        if event.state != 'published' and (
-            'Authorization' not in request.headers
-            or not has_access(permission, event_id=event.id)
-        ):
+
+    if event:
+        forbidden = not is_logged_in() or not has_access(permission, event_id=event.id)
+        if event.state != 'published' and forbidden:
             raise ObjectNotFound(
-                {'parameter': event_identifier},
-                "Event: {} not found".format(view_kwargs[event_identifier]),
+                {'parameter': event_id},
+                f"Event: {event.id} not found",
+            )
+        if restrict and forbidden:
+            raise ForbiddenError(
+                {'parameter': event_id},
+                f"You don't have access to event {event.id}",
             )
         query_ = query_.join(Event).filter(Event.id == event.id)
     return query_

--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -292,18 +292,6 @@ class OrdersList(ResourceList):
     OrderList class for OrderSchema
     """
 
-    def before_get(self, args, kwargs):
-        """
-        before get method to get the resource id for fetching details
-        :param args:
-        :param kwargs:
-        :return:
-        """
-        if kwargs.get('event_id') and not has_access(
-            'is_coorganizer', event_id=kwargs['event_id']
-        ):
-            raise ForbiddenError({'source': ''}, "Co-Organizer Access Required")
-
     def query(self, view_kwargs):
         query_ = self.session.query(Order)
         if view_kwargs.get('user_id'):
@@ -318,7 +306,7 @@ class OrdersList(ResourceList):
             )
         else:
             # orders under an event
-            query_ = event_query(query_, view_kwargs)
+            query_ = event_query(query_, view_kwargs, restrict=True)
 
         return query_
 

--- a/app/api/settings.py
+++ b/app/api/settings.py
@@ -5,6 +5,7 @@ from flask_rest_jsonapi import ResourceDetail
 from app.api.bootstrap import api
 from app.api.helpers.errors import UnprocessableEntityError
 from app.api.helpers.mail import send_test_email
+from app.api.helpers.permission_manager import is_logged_in
 from app.api.helpers.permissions import is_admin
 from app.api.schema.settings import (
     SettingSchemaAdmin,
@@ -39,7 +40,7 @@ class SettingDetail(ResourceDetail):
             refresh_settings()
         kwargs['id'] = 1
 
-        if 'Authorization' in request.headers:
+        if is_logged_in():
             verify_jwt_in_request()
 
             if current_user.is_admin or current_user.is_super_admin:

--- a/app/api/stripe_authorization.py
+++ b/app/api/stripe_authorization.py
@@ -1,11 +1,10 @@
-from flask import request
 from flask_rest_jsonapi import ResourceDetail, ResourceList
 from sqlalchemy.orm.exc import NoResultFound
 
 from app.api.helpers.db import get_count, safe_query_kwargs, save_to_db
 from app.api.helpers.errors import ConflictError, ForbiddenError, UnprocessableEntityError
 from app.api.helpers.payment import StripePaymentsManager
-from app.api.helpers.permission_manager import has_access
+from app.api.helpers.permission_manager import has_access, is_logged_in
 from app.api.helpers.permissions import jwt_required
 from app.api.helpers.utilities import require_relationship
 from app.api.schema.stripe_authorization import (
@@ -116,9 +115,7 @@ class StripeAuthorizationDetail(ResourceDetail):
         :return:
         """
         kwargs = get_id(kwargs)
-        if 'Authorization' in request.headers and has_access(
-            'is_coorganizer', event_id=kwargs['id']
-        ):
+        if is_logged_in() and has_access('is_coorganizer', event_id=kwargs['id']):
             self.schema = StripeAuthorizationSchema
         else:
             self.schema = StripeAuthorizationSchemaPublic

--- a/app/api/tax.py
+++ b/app/api/tax.py
@@ -1,4 +1,3 @@
-from flask import request
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
 from flask_rest_jsonapi.exceptions import ObjectNotFound
 from sqlalchemy.orm.exc import NoResultFound
@@ -6,7 +5,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from app.api.bootstrap import api
 from app.api.helpers.db import get_count, safe_query, safe_query_kwargs
 from app.api.helpers.errors import ConflictError, ForbiddenError, MethodNotAllowed
-from app.api.helpers.permission_manager import has_access
+from app.api.helpers.permission_manager import has_access, is_logged_in
 from app.api.helpers.utilities import require_relationship
 from app.api.schema.tax import TaxSchema, TaxSchemaPublic
 from app.models import db
@@ -67,7 +66,7 @@ class TaxList(ResourceList):
         :param kwargs:
         :return:
         """
-        if 'Authorization' in request.headers and has_access('is_admin'):
+        if is_logged_in() and has_access('is_admin'):
             self.schema = TaxSchema
         else:
             self.schema = TaxSchemaPublic
@@ -117,14 +116,12 @@ class TaxDetail(ResourceDetail):
                 tax = Tax.query.filter_by(id=kwargs['id']).one()
             except NoResultFound:
                 raise ObjectNotFound({'parameter': 'id'}, f"Tax: Not found for id {id}")
-            if 'Authorization' in request.headers and has_access(
-                'is_coorganizer', event_id=tax.event_id
-            ):
+            if is_logged_in() and has_access('is_coorganizer', event_id=tax.event_id):
                 self.schema = TaxSchema
             else:
                 self.schema = TaxSchemaPublic
         else:
-            if 'Authorization' in request.headers and has_access(
+            if is_logged_in() and has_access(
                 'is_coorganizer', event_id=kwargs['event_id']
             ):
                 self.schema = TaxSchema

--- a/app/api/tickets.py
+++ b/app/api/tickets.py
@@ -1,4 +1,3 @@
-from flask import request
 from flask_jwt_extended import current_user, verify_jwt_in_request
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
 from flask_rest_jsonapi.exceptions import ObjectNotFound
@@ -7,7 +6,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from app.api.bootstrap import api
 from app.api.helpers.db import get_count, safe_query_kwargs
 from app.api.helpers.errors import ConflictError, UnprocessableEntityError
-from app.api.helpers.permission_manager import has_access
+from app.api.helpers.permission_manager import has_access, is_logged_in
 from app.api.helpers.query import event_query
 from app.api.helpers.utilities import require_relationship
 from app.api.schema.tickets import TicketSchema, TicketSchemaPublic
@@ -123,7 +122,7 @@ class TicketList(ResourceList):
         :return:
         """
 
-        if 'Authorization' in request.headers:
+        if is_logged_in():
             verify_jwt_in_request()
             if current_user.is_super_admin or current_user.is_admin:
                 query_ = self.session.query(Ticket)

--- a/app/api/user_favourite_events.py
+++ b/app/api/user_favourite_events.py
@@ -1,4 +1,3 @@
-from flask import request
 from flask_jwt_extended import current_user, jwt_required, verify_jwt_in_request
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
 from flask_rest_jsonapi.exceptions import ObjectNotFound
@@ -6,7 +5,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from app.api.helpers.db import safe_query_kwargs
 from app.api.helpers.errors import ConflictError, ForbiddenError
-from app.api.helpers.permission_manager import has_access
+from app.api.helpers.permission_manager import has_access, is_logged_in
 from app.api.helpers.utilities import require_relationship
 from app.api.schema.user_favourite_events import UserFavouriteEventSchema
 from app.models import db
@@ -30,7 +29,7 @@ class UserFavouriteEventListPost(ResourceList):
         """
         require_relationship(['event'], data)
 
-        if 'Authorization' in request.headers:
+        if is_logged_in():
             verify_jwt_in_request()
         else:
             raise ForbiddenError(

--- a/tests/all/conftest.py
+++ b/tests/all/conftest.py
@@ -1,4 +1,6 @@
 import pytest
+from flask import _app_ctx_stack as ctx_stack
+from flask.globals import request
 from flask_jwt_extended.utils import create_access_token
 
 from app.models import db as _db
@@ -78,3 +80,30 @@ def jwt(user):
 @pytest.fixture
 def admin_jwt(admin_user):
     return {'Authorization': "JWT " + create_access_token(admin_user.id, fresh=True)}
+
+
+@pytest.fixture
+def login_context(client):
+    "Use only when above methods don't work"
+    yield ctx_stack
+
+    ctx_stack.top.jwt = {}
+    ctx_stack.top.jwt_user = None
+
+    request.headers = {}
+
+
+@pytest.fixture
+def user_login(login_context, user, jwt):
+    login_context.top.jwt = {'identity': user.id}
+    request.headers = jwt
+
+    yield user
+
+
+@pytest.fixture
+def admin_login(login_context, admin_user, admin_jwt):
+    login_context.top.jwt = {'identity': admin_user.id}
+    request.headers = admin_jwt
+
+    yield admin_user

--- a/tests/all/integration/api/attendee/test_attendee_access_api.py
+++ b/tests/all/integration/api/attendee/test_attendee_access_api.py
@@ -114,7 +114,7 @@ def test_get_event_attendees_anon_error(db, client):
         content_type='application/vnd.api+json',
     )
 
-    assert response.status_code == 403
+    assert response.status_code == 401
 
     attendee = get_minimal_attendee(db, event_status='draft')
 
@@ -123,7 +123,7 @@ def test_get_event_attendees_anon_error(db, client):
         content_type='application/vnd.api+json',
     )
 
-    assert response.status_code == 404
+    assert response.status_code == 401
 
 
 def test_get_event_attendees_user_error(db, client, user, jwt):

--- a/tests/all/integration/api/attendee/test_attendee_access_api.py
+++ b/tests/all/integration/api/attendee/test_attendee_access_api.py
@@ -1,0 +1,148 @@
+import json
+
+from app.api.helpers.db import get_or_create
+from app.models.role import Role
+from app.models.users_events_role import UsersEventsRoles
+from tests.factories.attendee import AttendeeOrderTicketSubFactory
+
+
+def get_minimal_attendee(db, user=None, owner=False, event_status='published'):
+    attendee = AttendeeOrderTicketSubFactory(
+        order__user=user if not owner else None, event__state=event_status
+    )
+    if owner:
+        role, _ = get_or_create(Role, name='owner', title_name='Owner')
+        UsersEventsRoles(user=user, event=attendee.event, role=role)
+    db.session.commit()
+
+    return attendee
+
+
+def test_get_attendees_error(db, client, user, jwt, admin_user, admin_jwt):
+    get_minimal_attendee(db, user)
+
+    response = client.get('/v1/attendees', content_type='application/vnd.api+json')
+
+    assert response.status_code == 405
+
+    response = client.get(
+        '/v1/attendees',
+        content_type='application/vnd.api+json',
+        headers=jwt,
+    )
+
+    assert response.status_code == 405
+
+    get_minimal_attendee(db, user, owner=True)
+
+    response = client.get(
+        '/v1/attendees',
+        content_type='application/vnd.api+json',
+        headers=jwt,
+    )
+
+    assert response.status_code == 405
+
+    get_minimal_attendee(db, admin_user, owner=True)
+
+    response = client.get(
+        '/v1/attendees',
+        content_type='application/vnd.api+json',
+        headers=admin_jwt,
+    )
+
+    assert response.status_code == 405
+
+
+def test_get_event_attendees_owner(db, client, user, jwt):
+    attendee = get_minimal_attendee(db, user, owner=True)
+
+    response = client.get(
+        f'/v1/events/{attendee.event_id}/attendees',
+        content_type='application/vnd.api+json',
+        headers=jwt,
+    )
+
+    assert response.status_code == 200
+    assert len(json.loads(response.data)['data']) == 1
+
+
+def test_get_draft_event_attendees_owner(db, client, user, jwt):
+    attendee = get_minimal_attendee(db, user, owner=True, event_status='draft')
+
+    response = client.get(
+        f'/v1/events/{attendee.event_id}/attendees',
+        content_type='application/vnd.api+json',
+        headers=jwt,
+    )
+
+    assert response.status_code == 200
+    assert len(json.loads(response.data)['data']) == 1
+
+
+def test_get_event_attendees_admin(db, client, admin_jwt):
+    attendee = get_minimal_attendee(db)
+
+    response = client.get(
+        f'/v1/events/{attendee.event_id}/attendees',
+        content_type='application/vnd.api+json',
+        headers=admin_jwt,
+    )
+
+    assert response.status_code == 200
+    assert len(json.loads(response.data)['data']) == 1
+
+
+def test_get_draft_event_attendees_admin(db, client, admin_jwt):
+    attendee = get_minimal_attendee(db, event_status='draft')
+
+    response = client.get(
+        f'/v1/events/{attendee.event_id}/attendees',
+        content_type='application/vnd.api+json',
+        headers=admin_jwt,
+    )
+
+    assert response.status_code == 200
+    assert len(json.loads(response.data)['data']) == 1
+
+
+def test_get_event_attendees_anon_error(db, client):
+    attendee = get_minimal_attendee(db)
+
+    response = client.get(
+        f'/v1/events/{attendee.event_id}/attendees',
+        content_type='application/vnd.api+json',
+    )
+
+    assert response.status_code == 403
+
+    attendee = get_minimal_attendee(db, event_status='draft')
+
+    response = client.get(
+        f'/v1/events/{attendee.event_id}/attendees',
+        content_type='application/vnd.api+json',
+    )
+
+    assert response.status_code == 404
+
+
+def test_get_event_attendees_user_error(db, client, user, jwt):
+    attendee = get_minimal_attendee(db, user)
+
+    response = client.get(
+        f'/v1/events/{attendee.event_id}/attendees',
+        content_type='application/vnd.api+json',
+        headers=jwt,
+    )
+
+    assert response.status_code == 403
+
+    attendee = get_minimal_attendee(db, event_status='draft')
+
+    response = client.get(
+        f'/v1/events/{attendee.event_id}/attendees',
+        content_type='application/vnd.api+json',
+        headers=jwt,
+    )
+
+    assert response.status_code == 404

--- a/tests/all/integration/api/helpers/test_query.py
+++ b/tests/all/integration/api/helpers/test_query.py
@@ -1,0 +1,117 @@
+import pytest
+from flask_rest_jsonapi.exceptions import ObjectNotFound
+
+from app.api.helpers.db import get_or_create
+from app.api.helpers.errors import ForbiddenError
+from app.api.helpers.query import event_query
+from app.models.event import Event
+from app.models.order import Order
+from app.models.role import Role
+from app.models.ticket import Ticket
+from app.models.users_events_role import UsersEventsRoles
+from tests.factories.event import EventFactoryBasic
+
+
+def test_query_no_op(client):
+    query = Order.query
+    assert event_query(query, {}) == query
+
+
+@pytest.fixture
+def event(db):
+    return EventFactoryBasic(id=123, identifier='ashgdas6d3', state='published')
+
+
+def test_query_event(event):
+    assert str(event_query(Order.query, {'event_id': event.id})) == str(
+        Order.query.join(Event).filter(Event.id == event.id)
+    )
+    assert str(event_query(Ticket.query, {'event_identifier': event.identifier})) == str(
+        Ticket.query.join(Event).filter(Event.id == event.id)
+    )
+
+
+def test_query_no_event(client):
+    with pytest.raises(ObjectNotFound):
+        event_query(Order.query, {'event_id': 123})
+
+
+def test_query_draft_event_error(event):
+    event.state = 'draft'
+    with pytest.raises(ObjectNotFound):
+        event_query(Ticket.query, {'event_id': event.id})
+    with pytest.raises(ObjectNotFound):
+        event_query(Order.query, {'event_identifier': event.identifier})
+
+
+def test_query_draft_event_user_error(event, user_login):
+    "Different user should not be able to access draft event of other user"
+    event.state = 'draft'
+    with pytest.raises(ObjectNotFound):
+        event_query(Ticket.query, {'event_id': event.id})
+    with pytest.raises(ObjectNotFound):
+        event_query(Order.query, {'event_identifier': event.identifier})
+
+
+def get_owner(event, user):
+    role, _ = get_or_create(Role, name='owner', title_name='Owner')
+    UsersEventsRoles(user=user, event=event, role=role)
+    return user
+
+
+def test_query_draft_event_organizer(event, user, user_login):
+    get_owner(event, user)
+    event.state = 'draft'
+
+    assert str(event_query(Order.query, {'event_id': event.id})) == str(
+        Order.query.join(Event).filter(Event.id == event.id)
+    )
+    assert str(event_query(Ticket.query, {'event_identifier': event.identifier})) == str(
+        Ticket.query.join(Event).filter(Event.id == event.id)
+    )
+
+
+def test_query_draft_event_admin(event, admin_login):
+    event.state = 'draft'
+
+    assert str(event_query(Order.query, {'event_id': event.id})) == str(
+        Order.query.join(Event).filter(Event.id == event.id)
+    )
+    assert str(event_query(Ticket.query, {'event_identifier': event.identifier})) == str(
+        Ticket.query.join(Event).filter(Event.id == event.id)
+    )
+
+
+def test_query_restricted_event_error(event):
+    with pytest.raises(ForbiddenError):
+        event_query(Ticket.query, {'event_id': event.id}, restrict=True)
+    with pytest.raises(ForbiddenError):
+        event_query(Order.query, {'event_identifier': event.identifier}, restrict=True)
+
+
+def test_query_restricted_event_user_error(event, user_login):
+    with pytest.raises(ForbiddenError):
+        event_query(Ticket.query, {'event_id': event.id}, restrict=True)
+    with pytest.raises(ForbiddenError):
+        event_query(Order.query, {'event_identifier': event.identifier}, restrict=True)
+
+
+def test_query_restricted_event_organizer(event, user, user_login):
+    get_owner(event, user)
+
+    assert str(event_query(Order.query, {'event_id': event.id}, restrict=True)) == str(
+        Order.query.join(Event).filter(Event.id == event.id)
+    )
+    assert str(
+        event_query(Ticket.query, {'event_identifier': event.identifier}, restrict=True)
+    ) == str(Ticket.query.join(Event).filter(Event.id == event.id))
+
+
+def test_query_restricted_event_admin(event, admin_login):
+
+    assert str(event_query(Order.query, {'event_id': event.id}, restrict=True)) == str(
+        Order.query.join(Event).filter(Event.id == event.id)
+    )
+    assert str(
+        event_query(Ticket.query, {'event_identifier': event.identifier}, restrict=True)
+    ) == str(Ticket.query.join(Event).filter(Event.id == event.id))


### PR DESCRIPTION
Fixes #7390 

- [x] Fix event query logic
- [x] Separate restricted queries and unrestricted queries
- [x] Throw unconditionally for draft events
- [x] Refactor and simplify login detection code