### PR TITLE
fix: Allow organizer info links

### DIFF
--- a/app/models/event.py
+++ b/app/models/event.py
@@ -231,7 +231,7 @@ class Event(SoftDeletionModel):
         return '<Event %r>' % self.name
 
     def __setattr__(self, name, value):
-        allow_link = name == 'description'
+        allow_link = name == 'description' or 'owner_description'
         if (
             name == 'owner_description'
             or name == 'description'


### PR DESCRIPTION

Fixes fossasia/open-event-frontend#5344

#### Short description of what this resolves:

Organizer info links can be saved now.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.
