### PR TITLE
fix: Show Location, Online Event, Mixed Event or To be Announced info correctly

### DIFF
--- a/app/templates/pdf/ticket_attendee.html
+++ b/app/templates/pdf/ticket_attendee.html
@@ -46,8 +46,19 @@
             <span class="label">Event</span><br>
             <span style="font-size: 20px;">{{ order.event.name }}</span><br><br>
 
-            <span class="label">Location</span><br>
-            <span style="font-size: 15px;"> {{order.event.location_name }}</span><br><br>
+            {% if order.event.online %}
+                {% if order.event.location_name %}
+                    <span class="label">Event taking place online and at</span></br>
+                    <span style="font-size: 15px;"> {{order.event.location_name }}</span><br><br>
+                {% else %}
+                    <span class="label">Online Event</span><br><br>
+                {% endif %}
+            {% elif order.event.location_name %}
+                <span class="label">At</span></br>
+                <span style="font-size: 15px;"> {{order.event.location_name }}</span><br><br>
+            {% else %}
+                <span class="label">Location or online event details to be announced</span><br><br>
+            {% endif %}
 
             <span class="label">Date and Time</span><br>
             <span style="font-size: 15px;">From: {{ order.event.starts_at | datetime(order.event.timezone) }}</span><br>

--- a/app/templates/pdf/ticket_purchaser.html
+++ b/app/templates/pdf/ticket_purchaser.html
@@ -47,8 +47,19 @@
             <span class="label">Event</span><br>
             <span style="font-size: 20px;">{{ order.event.name }}</span><br><br>
 
-            <span class="label">Location</span><br>
-            <span style="font-size: 15px;">{{ order.event.location_name }}</span><br><br>
+            {% if order.event.online %}
+                {% if order.event.location_name %}
+                    <span class="label">Event taking place online and at</span></br>
+                    <span style="font-size: 15px;"> {{order.event.location_name }}</span><br><br>
+                {% else %}
+                    <span class="label">Online Event</span><br><br>
+                {% endif %}
+            {% elif order.event.location_name %}
+                <span class="label">At</span></br>
+                <span style="font-size: 15px;"> {{order.event.location_name }}</span><br><br>
+            {% else %}
+                <span class="label">Location or online event details to be announced</span><br><br>
+            {% endif %}
 
             <span class="label">Date and Time</span><br>
             <span style="font-size: 15px;">From: {{ order.event.starts_at | datetime(order.event.timezone) }}</span><br>


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes  https://github.com/fossasia/open-event-frontend/issues/5614

#### Short description of what this resolves:

This PR update the area to show the information according to the attendee pdf as follows:
- When an event has a location, show "At" and the location behind.
- When an event is an online event show "Online Event"
- When the event is a mixed event show "Event taking place online and at [location here]."
- When an event location or online details are "to be announced" show: "Location or online event details to be announced".

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [X] All the functions created/modified in this PR contain relevant docstrings.

__screenshots__

![s5](https://user-images.githubusercontent.com/72552281/99181259-5498c900-2753-11eb-99e2-e6895348e63d.png)

![s6](https://user-images.githubusercontent.com/72552281/99181260-55c9f600-2753-11eb-854a-ba6f04a35e4d.png)

![s7](https://user-images.githubusercontent.com/72552281/99181261-56628c80-2753-11eb-80c2-a57ed1d809df.png)

![s8](https://user-images.githubusercontent.com/72552281/99181262-56fb2300-2753-11eb-84b4-46b048bfaf18.png)

