### PR TITLE
feat: add "withdrawn" and "canceled" speakers and sessions in statistics.

### DIFF
--- a/app/api/schema/event_statistics.py
+++ b/app/api/schema/event_statistics.py
@@ -31,6 +31,8 @@ class EventStatisticsGeneralSchema(Schema):
     sessions_confirmed = fields.Method("sessions_confirmed_count")
     sessions_pending = fields.Method("sessions_pending_count")
     sessions_rejected = fields.Method("sessions_rejected_count")
+    sessions_withdrawn = fields.Method("sessions_withdrawn_count")
+    sessions_canceled = fields.Method("sessions_canceled_count")
     speakers = fields.Method("speakers_count")
     sessions = fields.Method("sessions_count")
     sponsors = fields.Method("sponsors_count")
@@ -63,6 +65,16 @@ class EventStatisticsGeneralSchema(Schema):
             event_id=obj.id, state='rejected', deleted_at=None
         ).count()
 
+    def sessions_withdrawn_count(self, obj):
+        return Session.query.filter_by(
+            event_id=obj.id, state='withdrawn', deleted_at=None
+        ).count()
+
+    def sessions_canceled_count(self, obj):
+        return Session.query.filter_by(
+            event_id=obj.id, state='canceled', deleted_at=None
+        ).count()
+
     def speakers_count_type(self, obj, state='pending'):
         return SessionsSpeakersLink.query.filter_by(
             event_id=obj.id, session_state=state, deleted_at=None
@@ -73,12 +85,16 @@ class EventStatisticsGeneralSchema(Schema):
         confirmed = self.speakers_count_type(obj=obj, state='confirmed')
         pending = self.speakers_count_type(obj=obj, state='pending')
         rejected = self.speakers_count_type(obj=obj, state='rejected')
+        withdrawn = self.speakers_count_type(obj=obj, state='withdrawn')
+        canceled = self.speakers_count_type(obj=obj, state='canceled')
         total = Speaker.query.filter_by(event_id=obj.id, deleted_at=None).count()
         serial_data = {
             'accepted': accepted,
             'confirmed': confirmed,
             'pending': pending,
             'rejected': rejected,
+            'withdrawn': withdrawn,
+            'canceled': canceled,
             'total': total,
         }
         return serial_data


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #https://github.com/fossasia/open-event-frontend/issues/5010

required for https://github.com/fossasia/open-event-frontend/pull/5671

#### Short description of what this resolves:

On the events dashboard at https://eventyay.com/events/live in the speakers and sessions column the status "Withdrawn" and "Canceled" are missing. This PR add them.


#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [X] All the functions created/modified in this PR contain relevant docstrings.
