### PR TITLE
fix: Use identifier for export instead of field identifier

### DIFF
--- a/app/api/helpers/csv_jobs_util.py
+++ b/app/api/helpers/csv_jobs_util.py
@@ -76,10 +76,10 @@ def export_attendees_csv(attendees, custom_forms):
             if field.is_complex:
                 fields_dict = attendee.complex_field_values
                 column.append(
-                    fields_dict.get(field.field_identifier, '') if fields_dict else ''
+                    fields_dict.get(field.identifier, '') if fields_dict else ''
                 )
             else:
-                column.append(getattr(attendee, field.field_identifier, ''))
+                column.append(getattr(attendee, field.identifier, ''))
 
         rows.append(column)
 

--- a/app/templates/pdf/attendees_pdf.html
+++ b/app/templates/pdf/attendees_pdf.html
@@ -117,9 +117,9 @@
                  <td><br>
                      {% for field in custom_forms %}
                         {% if field.is_complex and holder.complex_field_values %}
-                            {{ holder.complex_field_values[field.field_identifier] }} <br>
+                            {{ holder.complex_field_values[field.identifier] }} <br>
                         {% else %}
-                            {{ holder | attr(field.field_identifier) }} <br>
+                            {{ holder | attr(field.identifier) }} <br>
                         {% endif %}
                      {% endfor %}
                     {% if holder.ticket.price %}


### PR DESCRIPTION
Fixes https://github.com/fossasia/open-event-frontend/issues/5643

`field_identifier` is saved as `jobTitle` instead of `job_title` for absolutely no good reason (other than weird JS centric approach to everything in the stack?), hence any field like country and firstname exported correctly, but `Job Title` didn't. That's why I had created `identifier` property previously which changes camel case to snake case and matches the attributes on attendee. Using this instead of `field_identifier` fixes the issue