### PR TITLE
Update api/schema/discount_codes.py to handle negative max_quantity 

### DIFF
--- a/app/api/schema/discount_codes.py
+++ b/app/api/schema/discount_codes.py
@@ -1,3 +1,5 @@
+from sys import maxsize
+
 from flask_rest_jsonapi.exceptions import ObjectNotFound
 from marshmallow import validate, validates_schema
 from marshmallow_jsonapi import fields
@@ -33,7 +35,10 @@ class DiscountCodeSchemaPublic(SoftDeletionSchema):
     is_active = fields.Boolean()
     tickets_number = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
     min_quantity = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
-    max_quantity = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
+    max_quantity = fields.Integer(allow_none=True)
+    if max_quantity < 0:
+        max_quantity = sys.maxsize
+        
     valid_from = fields.DateTime(allow_none=True)
     valid_till = fields.DateTime(allow_none=True)
     used_for = fields.Str(


### PR DESCRIPTION
No limit for discount code when max_quantity is negative. 

<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #7474

#### Short description of what this resolves:


#### Changes proposed in this pull request:

- Changed max_quantity attribute to take negative values also
- If value is negative then max_quantity should have no limit

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
