### PR TITLE
fix: event start time can be before current

### DIFF
--- a/app/api/events.py
+++ b/app/api/events.py
@@ -96,17 +96,6 @@ def validate_date(event, data):
             {'pointer': '/data/attributes/ends-at'}, "ends-at should be after starts-at"
         )
 
-    if datetime.timestamp(data['starts_at']) <= datetime.timestamp(datetime.now()):
-        if event and event.deleted_at and not data.get('deleted_at'):
-            data['state'] = 'draft'
-        elif event and not event.deleted_at and data.get('deleted_at'):
-            pass
-        else:
-            raise UnprocessableEntityError(
-                {'pointer': '/data/attributes/starts-at'},
-                "starts-at should be after current date-time",
-            )
-
 
 class EventList(ResourceList):
     def before_get(self, args, kwargs):


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes https://github.com/fossasia/open-event-frontend/issues/6021

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
