### PR TITLE
feat: return dummy for deleted users

### DIFF
--- a/app/api/schema/users.py
+++ b/app/api/schema/users.py
@@ -279,20 +279,15 @@ class UserSchema(UserSchemaPublic):
 
     @pre_dump
     def handle_deleted_users(self, data):
-        user = None
-        if (
-            not (
-                is_logged_in
-                and current_user
-                and data
-                and (current_user.is_staff or current_user.id == data.id)
-            )
-            and data.deleted_at != None
+        if not data:
+            return data
+        if data.deleted_at != None and not (
+            is_logged_in
+            and current_user
+            and (current_user.is_staff or current_user.id == data.id)
         ):
-            user = User()
-            user.email = 'deleted@eventyay.com'
-            user.first_name = 'deleted'
-            user.last_name = 'user'
-            user.deleted_at = data.deleted_at
-            user.id = data.id
-        return user if user else data
+            user = User(
+                id=0, email='deleted@eventyay.com', first_name='deleted', last_name='user'
+            )
+            return user
+        return data

--- a/tests/all/integration/api/attendee/test_attendee_access_api.py
+++ b/tests/all/integration/api/attendee/test_attendee_access_api.py
@@ -1,9 +1,12 @@
 import json
 
+from flask_jwt_extended.utils import create_access_token
+
 from app.api.helpers.db import get_or_create
 from app.models.role import Role
 from app.models.users_events_role import UsersEventsRoles
 from tests.factories.attendee import AttendeeOrderTicketSubFactory
+from tests.factories.user import UserFactory
 
 
 def get_minimal_attendee(db, user=None, owner=False, event_status='published'):
@@ -16,6 +19,68 @@ def get_minimal_attendee(db, user=None, owner=False, event_status='published'):
     db.session.commit()
 
     return attendee
+
+
+def test_get_attendee_user(db, client, user, jwt, admin_user, admin_jwt):
+
+    attendee = get_minimal_attendee(db, user)
+    organizer_user = UserFactory(is_admin=False)
+    role = get_or_create(Role, name='ORGANIZER', title_name='Organizer')
+    UsersEventsRoles(user=organizer_user, event_id=attendee.event_id, role=role)
+    db.session.commit()
+
+    response = client.get(
+        f'/v1/attendees/{attendee.id}?include=user',
+        content_type='application/vnd.api+json',
+        headers=admin_jwt,
+    )
+
+    assert response.status_code == 200
+    assert json.loads(response.data)['included'][0]['attributes']['email'] == user.email
+    assert (
+        json.loads(response.data)['included'][0]['attributes']['first-name']
+        == user.first_name
+    )
+    assert (
+        json.loads(response.data)['included'][0]['attributes']['last-name']
+        == user.last_name
+    )
+
+    response = client.get(
+        f'/v1/attendees/{attendee.id}?include=user',
+        content_type='application/vnd.api+json',
+        headers={
+            'Authorization': "JWT " + create_access_token(organizer_user.id, fresh=True)
+        },
+    )
+
+    assert response.status_code == 200
+    assert json.loads(response.data)['included'][0]['attributes']['email'] == user.email
+    assert (
+        json.loads(response.data)['included'][0]['attributes']['first-name']
+        == user.first_name
+    )
+    assert (
+        json.loads(response.data)['included'][0]['attributes']['last-name']
+        == user.last_name
+    )
+
+    response = client.get(
+        f'/v1/attendees/{attendee.id}?include=user',
+        content_type='application/vnd.api+json',
+        headers=jwt,
+    )
+
+    assert response.status_code == 200
+    assert json.loads(response.data)['included'][0]['attributes']['email'] == user.email
+    assert (
+        json.loads(response.data)['included'][0]['attributes']['first-name']
+        == user.first_name
+    )
+    assert (
+        json.loads(response.data)['included'][0]['attributes']['last-name']
+        == user.last_name
+    )
 
 
 def test_get_attendees_error(db, client, user, jwt, admin_user, admin_jwt):


### PR DESCRIPTION
Fixes #7424 

#### Short description of what this resolves:
Return dummy for deleted users by modifying the dump according to the permission level (super admin can see email and name) but others will get "deleted user" in response.

#### Checklist

- [ ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [ ] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
