### PR TITLE
feat: remove order.user relation when not purchaser

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1511,7 +1511,9 @@ api.route(
     OrderRelationship, 'order_ticket', '/orders/<order_identifier>/relationships/ticket'
 )
 api.route(
-    OrderRelationship, 'order_user', '/orders/<order_identifier>/relationships/user'
+    OrderRelationship,
+    'order_user',
+    '/orders/<order_identifier>/relationships/user',
 )
 api.route(
     OrderRelationship, 'order_event', '/orders/<order_identifier>/relationships/event'

--- a/app/api/schema/orders.py
+++ b/app/api/schema/orders.py
@@ -131,7 +131,8 @@ class OrderSchema(Schema):
         dump_only=True,
     )
 
-    user = Relationship(
+    user = GetterRelationship(
+        getter='safe_user',
         self_view='v1.order_user',
         self_view_kwargs={'order_identifier': '<identifier>'},
         related_view='v1.user_detail',

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -171,6 +171,20 @@ class Order(db.Model):
         return query_.all()
 
     @property
+    def safe_user(self):
+        from app.api.helpers.permission_manager import has_access
+
+        if (
+            not has_access(
+                'is_coorganizer',
+                event_id=self.event_id,
+            )
+            and current_user.id != self.user_id
+        ):
+            return None
+        return self.user
+
+    @property
     def site_view_link(self) -> str:
         frontend_url = get_settings()['frontend_url']
         return frontend_url + '/orders/' + self.identifier + '/view'

--- a/docs/api/blueprint/order/orders.apib
+++ b/docs/api/blueprint/order/orders.apib
@@ -196,11 +196,6 @@ Get a single Order detail.
                   "self": "/v1/orders/ab25a170-f36d-4dd6-b99c-9c202e693afc/relationships/marketer"
                 }
               },
-              "user": {
-                "links": {
-                  "self": "/v1/orders/ab25a170-f36d-4dd6-b99c-9c202e693afc/relationships/user"
-                }
-              },
               "discount-code": {
                 "links": {
                   "self": "/v1/orders/ab25a170-f36d-4dd6-b99c-9c202e693afc/relationships/discount-code"


### PR DESCRIPTION
Fixes #7476 

#### Short description of what this resolves:
Remove order.user relation when ticket holder is not purchaser.

#### Checklist

- [ ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [ ] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
