### PR TITLE
fix: allow session state change

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -217,7 +217,7 @@ SESSION_STATE_DICT = {
             'accepted': True,
             'rejected': True,
             'canceled': True,
-        },  # Withdrawn is final
+        },
     },
     'speaker': {
         'draft': {'pending': True},

--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -185,25 +185,39 @@ SESSION_STATE_DICT = {
             'confirmed': True,
         },
         'accepted': {
+            'pending': True,
             'withdrawn': True,
             'rejected': True,
             'confirmed': True,
             'canceled': True,
         },
         'confirmed': {
+            'pending': True,
             'withdrawn': True,
             'accepted': True,
             'rejected': True,
             'canceled': True,
         },
-        'rejected': {'withdrawn': True, 'accepted': True, 'confirmed': True},
+        'rejected': {
+            'pending': True,
+            'withdrawn': True,
+            'accepted': True,
+            'confirmed': True,
+        },
         'canceled': {
+            'pending': True,
             'withdrawn': True,
             'accepted': True,
             'rejected': True,
             'confirmed': True,
         },
-        'withdrawn': {},  # Withdrawn is final
+        'withdrawn': {
+            'pending': True,
+            'withdrawn': True,
+            'accepted': True,
+            'rejected': True,
+            'canceled': True,
+        },  # Withdrawn is final
     },
     'speaker': {
         'draft': {'pending': True},

--- a/tests/all/integration/api/session/test_session_state_api.py
+++ b/tests/all/integration/api/session/test_session_state_api.py
@@ -122,11 +122,6 @@ def test_withdraw_speaker_allow(db, client, user, jwt, new_state, state):
 states = _create_permutations(['withdrawn'], ['pending'])
 
 
-@pytest.mark.parametrize('state,new_state', states)
-def test_revert_withdraw_speaker_disallow(db, client, user, jwt, new_state, state):
-    _test_state_change(db, client, user, jwt, new_state, state=state, event_owner=False)
-
-
 def test_withdraw_speaker_error(
     db, client, user, jwt, new_state='withdrawn', state='draft'
 ):
@@ -144,12 +139,6 @@ def test_withdraw_organizer_allow(db, client, user, jwt, new_state, state):
 
 
 states = _create_permutations(['withdrawn'], ['accepted', 'confirmed', 'rejected'])
-
-
-@pytest.mark.parametrize('state,new_state', states)
-def test_revert_withdraw_organizer_disallow(db, client, user, jwt, new_state, state):
-    _test_state_change(db, client, user, jwt, new_state, state=state)
-
 
 states = _create_permutations(['pending'], ['accepted', 'confirmed', 'rejected'])
 
@@ -176,11 +165,6 @@ def test_canceled_organizer_allow(db, client, user, jwt, new_state, state):
 
 
 states = _create_permutations(['pending', 'rejected', 'withdrawn'], ['canceled'])
-
-
-@pytest.mark.parametrize('state,new_state', states)
-def test_canceled_organizer_disallow(db, client, user, jwt, new_state, state):
-    _test_state_change(db, client, user, jwt, new_state, state=state)
 
 
 def test_confirmed_organizer_allow(


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes https://github.com/fossasia/open-event-frontend/issues/6566
   - not allowing state change from pending to canceled. I Will change if this is also needed. But I thought it should be this way.
  

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
