### PR TITLE
fix: Correct precision of event invoice amount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,7 @@ src
 generated/
 
 docker-compose.override.yml
-celerybeat-schedule.*
+celerybeat-schedule*
 .coverage
 .pytype
 .tool-versions

--- a/app/models/event_invoice.py
+++ b/app/models/event_invoice.py
@@ -185,7 +185,7 @@ class EventInvoice(SoftDeletionModel):
         frontend_url = get_settings()['frontend_url']
         link = f'{frontend_url}/event-invoice/{self.identifier}/review'
         currency = self.event.payment_currency
-        amount = f"{currency} {self.amount}"
+        amount = f"{currency} {self.amount:.2f}"
         send_email_for_monthly_fee_payment(
             self.user,
             self.event.name,


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #7743 

#### Short description of what this resolves:
Trailing zero of the second decimal place was ignored in the case of an event invoice. Fixed that. Also corrected the format of `celerybeat-schedule` type ignore files in `.gitignore`.

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [X] All the functions created/modified in this PR contain relevant docstrings.
