### PR TITLE
feat: BBB getRecording endpoint

### DIFF
--- a/app/api/video_stream.py
+++ b/app/api/video_stream.py
@@ -18,7 +18,7 @@ from app.api.helpers.errors import (
     UnprocessableEntityError,
 )
 from app.api.helpers.permission_manager import has_access
-from app.api.helpers.permissions import jwt_required
+from app.api.helpers.permissions import is_coorganizer, jwt_required, to_event_id
 from app.api.helpers.utilities import require_exclusive_relationship
 from app.api.schema.video_stream import VideoStreamSchema
 from app.api.video_channels.bbb import BigBlueButton
@@ -129,7 +129,9 @@ def create_bbb_meeting(channel, data):
     '/<int:stream_id>/getRecordings',
 )
 @jwt_required
-def getBBBrecordings(stream_id: int):
+@to_event_id
+@is_coorganizer
+def get_bbb_recordings(stream_id: int):
     stream = VideoStream.query.get_or_404(stream_id)
     if not stream.user_can_access:
         raise NotFoundError({'source': ''}, 'Video Stream Not Found')
@@ -152,6 +154,8 @@ def getBBBrecordings(stream_id: int):
     '/<int:stream_id>/chat-token',
 )
 @jwt_required
+@to_event_id
+@is_coorganizer
 def get_chat_token(stream_id: int):
     stream = VideoStream.query.get_or_404(stream_id)
     if not stream.user_can_access:

--- a/app/api/video_stream.py
+++ b/app/api/video_stream.py
@@ -133,7 +133,7 @@ def get_bbb_recordings(stream_id: int):
     stream = VideoStream.query.get_or_404(stream_id)
     if not has_access('is_organizer', event_id=stream.event_id):
         raise ForbiddenError(
-            {'source': ''},
+            {'pointer': 'event_id'},
             'You need to be the event organizer to access video recordings.',
         )
 

--- a/app/api/video_stream.py
+++ b/app/api/video_stream.py
@@ -126,7 +126,7 @@ def create_bbb_meeting(channel, data):
 
 
 @streams_routes.route(
-    '/<int:stream_id>/getRecordings',
+    '/<int:stream_id>/recordings',
 )
 @jwt_required
 @to_event_id


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->


discussed in meeting

response:

```
{
    "result": {
        "response": {
            "recordings": {
                "recording": {
                    "data": null,
                    "endTime": "1616023564490",
                    "internalMeetingID": "e508457f48e26089abe4015da18ac51c9cb37640-1616023512955",
                    "isBreakout": "false",
                    "meetingID": "318c6500-b9f0-477b-a6ea-7bd52151e595",
                    "metadata": {
                        "isBreakout": "false",
                        "meetingId": "318c6500-b9f0-477b-a6ea-7bd52151e595",
                        "meetingName": "poye1"
                    },
                    "name": "poye1",
                    "participants": "1",
                    "playback": {
                        "format": {
                            "length": "0",
                            "preview": {
                                "images": {
                                    "image": [
                                        {
                                            "#text": "https://video.eventyay.com/presentation/e508457f48e26089abe4015da18ac51c9cb37640-1616023512955/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1616023512967/thumbnails/thumb-1.png",
                                            "@alt": "Welcome To BigBlueButton",
                                            "@height": "136",
                                            "@width": "176"
                                        },
                                        {
                                            "#text": "https://video.eventyay.com/presentation/e508457f48e26089abe4015da18ac51c9cb37640-1616023512955/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1616023512967/thumbnails/thumb-2.png",
                                            "@alt": "This slide left blank for whiteboard",
                                            "@height": "136",
                                            "@width": "176"
                                        },
                                        {
                                            "#text": "https://video.eventyay.com/presentation/e508457f48e26089abe4015da18ac51c9cb37640-1616023512955/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1616023512967/thumbnails/thumb-3.png",
                                            "@alt": "This slide left blank for whiteboard",
                                            "@height": "136",
                                            "@width": "176"
                                        }
                                    ]
                                }
                            },
                            "processingTime": "7298",
                            "size": "317069",
                            "type": "presentation",
                            "url": "https://video.eventyay.com/playback/presentation/2.0/playback.html?meetingId=e508457f48e26089abe4015da18ac51c9cb37640-1616023512955"
                        }
                    },
                    "published": "true",
                    "rawSize": "1416937",
                    "recordID": "e508457f48e26089abe4015da18ac51c9cb37640-1616023512955",
                    "size": "317069",
                    "startTime": "1616023512955",
                    "state": "published"
                }
            },
            "returncode": "SUCCESS"
        }
    }
}
```

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
