### PR TITLE
fix: encode session link in ical

### DIFF
--- a/app/api/helpers/calendar/ical.py
+++ b/app/api/helpers/calendar/ical.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote
+
 import pytz
 from flask import jsonify
 from flask_jwt_extended import current_user
@@ -57,7 +59,7 @@ def to_ical(event, include_sessions=False, my_schedule=False, user_id=None):
                 " "
                 + event.site_link
                 + '/video/'
-                + session.microlocation.video_stream.name
+                + quote(session.microlocation.video_stream.name)
                 + "/"
                 + str(session.microlocation.video_stream.id)
                 if session.microlocation.video_stream


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #7842

encode session link in ical


![1](https://user-images.githubusercontent.com/72552281/113293908-fe987c80-9313-11eb-8302-815155d0c540.png)
