### PR TITLE
fix: only allow event owners to add event to group

### DIFF
--- a/app/api/groups.py
+++ b/app/api/groups.py
@@ -32,8 +32,8 @@ class GroupListPost(ResourceList):
             raise ForbiddenError({'source': ''}, 'Access Forbidden')
 
         for event in data.get('events', []):
-            if not has_access('is_coorganizer', event_id=event):
-                raise ForbiddenError({'source': ''}, "Event co-organizer access required")
+            if not has_access('is_owner', event_id=event):
+                raise ForbiddenError({'source': ''}, "Event owner access required")
 
     schema = GroupSchema
     decorators = (jwt_required,)
@@ -107,8 +107,8 @@ class GroupDetail(ResourceDetail):
         """
 
         for event in data.get('events', []):
-            if not has_access('is_coorganizer', event_id=event):
-                raise ForbiddenError({'source': ''}, "Event co-organizer access required")
+            if not has_access('is_owner', event_id=event):
+                raise ForbiddenError({'source': ''}, "Event owner access required")
 
     decorators = (
         api.has_permission(

--- a/app/models/session.py
+++ b/app/models/session.py
@@ -134,7 +134,7 @@ class Session(SoftDeletionModel):
 
     def __setattr__(self, name, value):
         if name == 'short_abstract' or name == 'long_abstract' or name == 'comments':
-            super().__setattr__(name, clean_html(clean_up_string(value)))
+            super().__setattr__(name, clean_html(clean_up_string(value), allow_link=True))
         else:
             super().__setattr__(name, value)
 

--- a/app/models/session.py
+++ b/app/models/session.py
@@ -134,7 +134,7 @@ class Session(SoftDeletionModel):
 
     def __setattr__(self, name, value):
         if name == 'short_abstract' or name == 'long_abstract' or name == 'comments':
-            super().__setattr__(name, clean_html(clean_up_string(value), allow_link=True))
+            super().__setattr__(name, clean_html(clean_up_string(value)))
         else:
             super().__setattr__(name, value)
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #as per discussion

- only allow event owners to add event to group 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
