### PR TITLE
fix: Remove duplicate route for group roles

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -292,7 +292,6 @@ api.route(
     '/favourite-sessions/<int:user_favourite_session_id>/user',
     '/speakers/<int:speaker_id>/user',
     '/users-events-roles/<int:users_events_roles_id>/user',
-    '/users-groups-roles/<int:users_groups_roles_id>/user'
     '/video-stream-moderator/<int:video_stream_moderator_id>/user',
 )
 api.route(


### PR DESCRIPTION
@maze-runnar There was a duplicate route without a comma in the user detail routes which broke the video moderator route