### PR TITLE
fix: Show event link if event is online event in "Location Field" in ical

### DIFF
--- a/app/models/event.py
+++ b/app/models/event.py
@@ -441,7 +441,7 @@ class Event(SoftDeletionModel):
         if self.location_name:
             return self.location_name
         elif self.online:
-            return 'Online'
+            return self.site_link
         return 'Location Not Announced'
 
     @property


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes https://github.com/fossasia/open-event-frontend/issues/7184


Show event link if event is online event in "Location Field" in ical


![1](https://user-images.githubusercontent.com/72552281/117130408-a72b7780-adbd-11eb-8b74-760bdd2d4849.png)
