### PR TITLE
fix: gravatar for attendees without profile picture

### DIFF
--- a/app/models/user_favourite_session.py
+++ b/app/models/user_favourite_session.py
@@ -37,4 +37,8 @@ class UserFavouriteSession(db.Model, Timestamp):
                 public_name=name,
                 avatar_url=f'https://www.gravatar.com/avatar/{name_hash}?d=retro',
             )
+        if not self.user.avatar_url and not self.user.thumbnail_image_url:
+            name = self.user.anonymous_name
+            name_hash = md5(name.encode('utf-8')).hexdigest()
+            self.user.avatar_url = f'https://www.gravatar.com/avatar/{name_hash}?d=retro'
         return self.user


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes https://github.com/fossasia/open-event-frontend/issues/6813

#### Short description of what this resolves:

if users profile is private then we see gravatar instead of his picture in attendee list.
If User is public then We see his/her Image.
But if user haven't upload his image then we see placeholder/avatar.png .


After this PR we see gravatar If profile is public and user haven't uploaded image.

## Private User
![2](https://user-images.githubusercontent.com/72552281/119201637-f1467580-baac-11eb-9fdb-5ea30eb8836e.png)


## Public User who uploaded an Image
![1](https://user-images.githubusercontent.com/72552281/119201647-f6a3c000-baac-11eb-8ba4-a7773c985ec9.png)


## public user who haven't uploaded any profile image
![3](https://user-images.githubusercontent.com/72552281/119201660-f99eb080-baac-11eb-9a14-d7d3102f7a31.png)


