### PR TITLE
fix: Enable moderators of an event to access the event without getting a ticket

### DIFF
--- a/app/models/video_stream.py
+++ b/app/models/video_stream.py
@@ -9,6 +9,7 @@ from app.models.session import Session
 from app.models.speaker import Speaker
 from app.models.ticket_holder import TicketHolder
 from app.models.video_channel import VideoChannel
+from app.models.video_stream_moderator import VideoStreamModerator
 
 
 class VideoStream(db.Model):
@@ -85,11 +86,20 @@ class VideoStream(db.Model):
         return user.email in list(map(lambda x: x.email, self.moderators))
 
     @property
+    def user_is_video_moderator(self):
+        user = current_user
+        if VideoStreamModerator.query.filter_by(email=user.email).first():
+            return True
+
+        return False
+
+    @property
     def user_can_access(self):
         if not current_user or not (self.event_id or self.rooms):
             return False
         return (
             self.user_is_moderator
+            or self.user_is_video_moderator
             or self.user_is_speaker(self._event_id)
             or db.session.query(
                 TicketHolder.query.filter_by(event_id=self._event_id, user=current_user)

--- a/app/templates/email/video_stream_moderator.html
+++ b/app/templates/email/video_stream_moderator.html
@@ -1,5 +1,6 @@
 {{ _('Hello') }},
 <br/><br/>{{ _('You have been added as a video moderator of video %(video)s at event %(event)s.', video=video_stream_name, event=event_name) }}
+<br/><br/>{{ _('Moderators will get access to the event automatically. You do not need to get an additional ticket to access the event and moderator privileges.') }}
 {% if not user %}
     <br/><br/>
     {{ _('You need to register on the platform to access the video stream.') }}


### PR DESCRIPTION
Fixes [#7334](https://github.com/fossasia/open-event-frontend/issues/7334)

#### Short description of what this resolves:
self-explanatory

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [ ] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
