### PR TITLE
fix: enable recording of BBB video stream by default

### DIFF
--- a/app/api/video_stream.py
+++ b/app/api/video_stream.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 streams_routes = Blueprint('streams', __name__, url_prefix='/v1/video-streams')
 
-default_options = {'record': False, 'autoStartRecording': False, 'muteOnStart': True}
+default_options = {'record': True, 'autoStartRecording': False, 'muteOnStart': True}
 
 
 def check_same_event(room_ids):


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

enable recording of BBB video stream by default