### PR TITLE
fix: Loading all events which are owned and organised by user, on dashboard

### DIFF
--- a/app/api/events.py
+++ b/app/api/events.py
@@ -68,7 +68,6 @@ from app.models.user import (
 )
 from app.models.user_favourite_event import UserFavouriteEvent
 from app.models.users_events_role import UsersEventsRoles
-from app.models.users_groups_role import UsersGroupsRoles
 from app.models.video_stream import VideoStream
 
 events_blueprint = Blueprint('events_blueprint', __name__, url_prefix='/v1/events')
@@ -215,18 +214,7 @@ class EventList(ResourceList):
             if not has_access('is_user_itself', user_id=int(view_kwargs['user_id'])):
                 raise ForbiddenError({'source': ''}, 'Access Forbidden')
             user = safe_query_kwargs(User, view_kwargs, 'user_id')
-
-            query_ = query_.join(Event.roles).filter(
-                or_(
-                    UsersEventsRoles.user_id == user.id,
-                    and_(
-                        Group.id == UsersGroupsRoles.group_id,
-                        Event.group_id == Group.id,
-                        UsersGroupsRoles.email == current_user.email,
-                        UsersGroupsRoles.accepted == True,
-                    ),
-                )
-            )
+            query_ = query_.join(Event.roles).filter_by(user_id=user.id)
 
         if view_kwargs.get('user_owner_id') and 'GET' in request.method:
             if not has_access(


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes https://github.com/fossasia/open-event-frontend/issues/7419


Loading all events which are owned and organised by user, on dashboard

![23](https://user-images.githubusercontent.com/72552281/121514092-41a85780-ca09-11eb-90fb-c8dbfe041db2.png)

