### PR TITLE
fix: Load notification if target of notification is null

### DIFF
--- a/app/api/schema/notifications.py
+++ b/app/api/schema/notifications.py
@@ -38,6 +38,10 @@ class NotificationContentSchema(NormalSchema):
 
     @post_dump(pass_original=True)
     def add_target(self, data, obj):
+        if obj.target is None:
+            # handler -> if target data is deleted after generation of notification.
+            # to be implemented in future -> delete notification if target is deleted ex. RoleInvite.
+            return {}
         event = None
         if obj.target_type == 'Order':
             serialized = normalize_jsonapi_data(


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes https://github.com/fossasia/open-event-frontend/issues/7397


See in screenshot:- notification is loading with with content as `{}`

![24](https://user-images.githubusercontent.com/72552281/121523569-fc3d5780-ca13-11eb-95a2-ae30a6e27458.png)
