### PR TITLE
fix: change 'Test Slide' to 'Slides'

### DIFF
--- a/app/models/custom_form.py
+++ b/app/models/custom_form.py
@@ -81,7 +81,7 @@ CUSTOM_FORM_IDENTIFIER_NAME_MAP = {
         "level": "Level",
         "language": "Language",
         "slidesUrl": "Slide",
-        "slides": "Test Slide",
+        "slides": "Slides",
         "videoUrl": "Video",
         "audioUrl": "Audio",
         "website": "Website",


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

For [#7735](https://github.com/fossasia/open-event-frontend/issues/7735)

#### Short description of what this resolves:
In the sessions-speaker form, Slides appear as Test Slide
![ss_1630328343](https://user-images.githubusercontent.com/42090582/132092975-2bb75060-de9b-4659-9453-ab08d41cf3d2.png)



#### Changes proposed in this pull request:
`Test Slide` changed to **`Slides`**
