### PR TITLE
fix: remove html tags from ical description

### DIFF
--- a/app/api/helpers/calendar/ical.py
+++ b/app/api/helpers/calendar/ical.py
@@ -1,6 +1,7 @@
 from urllib.parse import quote
 
 import pytz
+from app.api.helpers.utilities import remove_html_tags
 from flask import jsonify
 from flask_jwt_extended import current_user
 from icalendar import Calendar, Event
@@ -24,11 +25,11 @@ def to_ical(event, include_sessions=False, my_schedule=False, user_id=None):
     event_component.add('dtstart', event.starts_at_tz)
     event_component.add('dtend', event.ends_at_tz)
     event_component.add('location', event.normalized_location)
-    event_component.add('description', event.description)
+    event_component.add('description', remove_html_tags(event.description))
     if event.has_coordinates:
         event_component.add('geo', (event.latitude, event.longitude))
     if event.owner_description:
-        event_component.add('organizer', event.owner_description)
+        event_component.add('organizer', remove_html_tags(event.owner_description))
 
     cal.add_component(event_component)
 
@@ -95,7 +96,7 @@ def to_ical(event, include_sessions=False, my_schedule=False, user_id=None):
             session_component.add(
                 'dtend', session.ends_at.astimezone(pytz.timezone(event.timezone))
             )
-            session_component.add('description', session_description)
+            session_component.add('description', remove_html_tags(session_description))
             session_component.add('url', event.site_link + '/session/' + str(session.id))
 
             cal.add_component(session_component)

--- a/app/api/helpers/utilities.py
+++ b/app/api/helpers/utilities.py
@@ -73,6 +73,10 @@ def require_exclusive_relationship(resource_list, data, optional=False):
         )
 
 
+def remove_html_tags(raw_html):
+    return re.sub('<.*?>', '', raw_html)
+
+
 def string_empty(value):
     return isinstance(value, str) and not value.strip()
 


### PR DESCRIPTION
Needed for [frontend#8179](https://github.com/fossasia/open-event-frontend/issues/8179)

ical description would be without html tags