### PR TITLE
fix: remove after order msg if empty

### DIFF
--- a/app/templates/email/ticket_purchased.html
+++ b/app/templates/email/ticket_purchased.html
@@ -21,7 +21,7 @@
                                     <a href="https://calendar.yahoo.com/?v=60&title={{ order.event.name }}&st={{ order.event.starts_at.strftime('%Y%m%dT%H%M') }}&et={{ order.event.ends_at.strftime('%Y%m%dT%H%M') }}&desc={{ order.event.description }}&in_loc={{ order.event.normalized_location }}">{{ _('Yahoo') }}</a> &bull;
                                     <a href="https://outlook.live.com/calendar/0/deeplink/compose?subject={{ order.event.name }}&startdt={{ order.event.starts_at.strftime('%Y-%m-%dT%H:%M') }}&enddt={{ order.event.ends_at.strftime('%Y-%m-%dT%H:%M') }}&body={{ order.event.description }}&location={{ order.event.normalized_location }}">{{ _('Outlook') }}</a>
 <br/>
-{% if order.event.after_order_message %}
+{% if order.event.after_order_message | strip_tags != '' %}
     <br/>{{ _('Below you find a message from the organizer') }}:
     <br/>
     <div style="white-space: pre-line;">

--- a/app/templates/email/ticket_purchased_attendee.html
+++ b/app/templates/email/ticket_purchased_attendee.html
@@ -15,7 +15,7 @@
 <br/>{{ order.event.normalized_location }}
 <br/><br/>{{ _('Best regards') }},
 <br/>{{ settings.app_name }} {{ _('Team') }}
-{% if order.event.after_order_message %}
+{% if order.event.after_order_message | strip_tags != '' %}
     <br/><br/>{{ _('Below you find a message from the organizer') }}:
     <br/><br/>
     <div style="white-space: pre-line;">


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #8641 
![Screenshot 2022-04-10 at 19-25-47 See you at order-msg on 10 May 2022 at 00 00 (India Standard Time) (O1649598389-209) - sh](https://user-images.githubusercontent.com/42090582/162622189-46bcd3da-2f6b-49d0-848e-8c46756554fd.png)
