### PR TITLE
fix: make app name appear only when logo is not there

### DIFF
--- a/app/templates/pdf/event_invoice.html
+++ b/app/templates/pdf/event_invoice.html
@@ -146,8 +146,9 @@
     <div id="logo">
       {% if admin_info.admin_billing_logo %}  
         <img src="{{admin_info.admin_billing_logo}}" alt="organization logo"  /><br>
+      {% else %}
+        {{ admin_info.app_name }}
       {% endif %}
-      {{ admin_info.app_name }}
     </div>
     <header class="clearfix">
       <h1>INVOICE {{ invoice.identifier }}</h1>

--- a/app/templates/pdf/order_invoice.html
+++ b/app/templates/pdf/order_invoice.html
@@ -170,8 +170,9 @@
   <div id="logo">
     {% if admin_info.admin_billing_logo %}
     <img src="{{admin_info.admin_billing_logo}}" alt="organization logo" /><br>
-    {% endif %}
+    {% else %}
     {{ admin_info.app_name }}
+    {% endif %}
   </div>
   <header class="clearfix">
     <h1>{{ _('INVOICE') }} {{order.created_at.strftime("%Y")}}E-{{ event.identifier }}{{'%06d' |

--- a/app/templates/pdf/ticket_attendee.html
+++ b/app/templates/pdf/ticket_attendee.html
@@ -133,8 +133,9 @@
                 <div id="billing_logo">
                     {% if admin_info.admin_billing_logo %}
                     <img src="{{admin_info.admin_billing_logo}}" alt="organization logo" /><br>
-                    {% endif %}
+                    {% else %}
                     <span id="app_name">{{app_name}}</span>
+                    {% endif %}
                 </div>
             </td>
 

--- a/app/templates/pdf/ticket_purchaser.html
+++ b/app/templates/pdf/ticket_purchaser.html
@@ -129,8 +129,9 @@
                 <div id="billing_logo">
                     {% if admin_info.admin_billing_logo %}
                     <img src="{{admin_info.admin_billing_logo}}" alt="organization logo" /><br>
-                    {% endif %}
+                    {% else %}
                     <span id="app_name">{{app_name}}</span>
+                    {% endif %}
                 </div>
             </td>
 


### PR DESCRIPTION
Fixes #8642 

![Screenshot 2022-04-13 at 16-21-46 test-free-reg-Tickets-812a9180-41dc-4299-b89e-c2a0e06ff62e pdf](https://user-images.githubusercontent.com/42090582/163165913-b929e23a-c2f9-4db0-ae02-2c30612ffdb6.png)

@mariobehling For the translation part, user has to change the user locale setting in their account to their desired language.
As for other parts, I have chosen **hindi** as a locale, for which translation is not present. That's why it's in english.