### PR TITLE
Add .python-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ celerybeat-schedule*
 .pytype
 .tool-versions
 *.mo
+.python-version


### PR DESCRIPTION
SSIA

.python-version is used to select Python interpreter wiht pyenv
