### PR TITLE
Bump base image to Python 3.8.17 on Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.6-alpine as base
+FROM python:3.8.17-alpine as base
 
 ####
 


### PR DESCRIPTION
This fixes install errors because for the old version no wheels are available, and building from source requires rust