### PR TITLE
feature-8878:Can't read errors related to unfilled fields in the form

### DIFF
--- a/app/api/helpers/custom_forms.py
+++ b/app/api/helpers/custom_forms.py
@@ -60,13 +60,13 @@ def validate_custom_form_constraints(form, obj, excluded):
             continue
         if not field.is_complex:
             if not getattr(obj, field.identifier):
-                missing_required_fields.append(field.identifier)
+                missing_required_fields.append(field.name)
         else:
             if obj.complex_field_values:
                 if obj.complex_field_values.get(field.identifier) is None:
-                    missing_required_fields.append(field.identifier)
+                    missing_required_fields.append(field.name)
             else:
-                missing_required_fields.append(field.identifier)
+                missing_required_fields.append(field.name)
 
     if len(missing_required_fields) > 0:
         raise UnprocessableEntityError(

--- a/tests/all/integration/api/attendee/test_attendee_api.py
+++ b/tests/all/integration/api/attendee/test_attendee_api.py
@@ -94,7 +94,7 @@ def test_edit_attendee_required_fields_missing(db, client, jwt, user):
     assert json.loads(response.data) == {
         'errors': [
             {
-                'detail': "Missing required fields ['email', 'tax_business_info']",
+                'detail': "Missing required fields ['Email', 'Tax Business Info']",
                 'source': {'pointer': '/data/attributes'},
                 'status': 422,
                 'title': 'Unprocessable Entity',
@@ -208,7 +208,7 @@ def test_custom_form_complex_fields_missing_required(db, client, jwt, user):
     assert json.loads(response.data) == {
         'errors': [
             {
-                'detail': "Missing required fields ['best_friend', 'job_title']",
+                'detail': "Missing required fields ['Best Friend', 'Job Title']",
                 'source': {'pointer': '/data/attributes'},
                 'status': 422,
                 'title': 'Unprocessable Entity',
@@ -290,7 +290,7 @@ def test_custom_form_complex_fields_missing_required_one(db, client, jwt, user):
     assert json.loads(response.data) == {
         'errors': [
             {
-                'detail': "Missing required fields ['best_friend']",
+                'detail': "Missing required fields ['Best Friend']",
                 'source': {'pointer': '/data/attributes'},
                 'status': 422,
                 'title': 'Unprocessable Entity',

--- a/tests/all/integration/api/helpers/order/test_edit_order.py
+++ b/tests/all/integration/api/helpers/order/test_edit_order.py
@@ -199,7 +199,7 @@ def test_order_pending_incomplete_complex_custom_form(client, db, user, jwt):
                 'status': 422,
                 'source': {'pointer': '/data/attributes'},
                 'title': 'Unprocessable Entity',
-                'detail': "Missing required fields ['What college', 'What university']",
+                'detail': "Missing required fields ['what college', 'what university']",
             }
         ],
         'jsonapi': {'version': '1.0'},
@@ -238,7 +238,7 @@ def test_order_placed_incomplete_complex_custom_form(client, db, user, jwt):
                 'status': 422,
                 'source': {'pointer': '/data/attributes'},
                 'title': 'Unprocessable Entity',
-                'detail': "Missing required fields ['What college', 'What university']",
+                'detail': "Missing required fields ['what college', 'what university']",
             }
         ],
         'jsonapi': {'version': '1.0'},

--- a/tests/all/integration/api/helpers/order/test_edit_order.py
+++ b/tests/all/integration/api/helpers/order/test_edit_order.py
@@ -199,7 +199,7 @@ def test_order_pending_incomplete_complex_custom_form(client, db, user, jwt):
                 'status': 422,
                 'source': {'pointer': '/data/attributes'},
                 'title': 'Unprocessable Entity',
-                'detail': "Missing required fields ['what_college', 'what_university']",
+                'detail': "Missing required fields ['What College', 'What University']",
             }
         ],
         'jsonapi': {'version': '1.0'},
@@ -238,7 +238,7 @@ def test_order_placed_incomplete_complex_custom_form(client, db, user, jwt):
                 'status': 422,
                 'source': {'pointer': '/data/attributes'},
                 'title': 'Unprocessable Entity',
-                'detail': "Missing required fields ['what_college', 'what_university']",
+                'detail': "Missing required fields ['What College', 'What University']",
             }
         ],
         'jsonapi': {'version': '1.0'},

--- a/tests/all/integration/api/helpers/order/test_edit_order.py
+++ b/tests/all/integration/api/helpers/order/test_edit_order.py
@@ -199,7 +199,7 @@ def test_order_pending_incomplete_complex_custom_form(client, db, user, jwt):
                 'status': 422,
                 'source': {'pointer': '/data/attributes'},
                 'title': 'Unprocessable Entity',
-                'detail': "Missing required fields ['What College', 'What University']",
+                'detail': "Missing required fields ['What college', 'What university']",
             }
         ],
         'jsonapi': {'version': '1.0'},
@@ -238,7 +238,7 @@ def test_order_placed_incomplete_complex_custom_form(client, db, user, jwt):
                 'status': 422,
                 'source': {'pointer': '/data/attributes'},
                 'title': 'Unprocessable Entity',
-                'detail': "Missing required fields ['What College', 'What University']",
+                'detail': "Missing required fields ['What college', 'What university']",
             }
         ],
         'jsonapi': {'version': '1.0'},

--- a/tests/all/integration/api/session/test_session_forms_api.py
+++ b/tests/all/integration/api/session/test_session_forms_api.py
@@ -328,7 +328,7 @@ def test_custom_form_complex_fields_missing_required(db, client, user, jwt):
     assert json.loads(response.data) == {
         'errors': [
             {
-                'detail': "Missing required fields ['best_friend', 'slides_url']",
+                'detail': "Missing required fields ['Best Friend', 'Slides']",
                 'source': {'pointer': '/data/attributes'},
                 'status': 422,
                 'title': 'Unprocessable Entity',
@@ -377,7 +377,7 @@ def test_custom_form_create_complex_fields_missing_required(db, client, user, jw
     assert json.loads(response.data) == {
         'errors': [
             {
-                'detail': "Missing required fields ['best_friend', 'slides_url']",
+                'detail': "Missing required fields ['Best_friend', 'Slides']",
                 'source': {'pointer': '/data/attributes'},
                 'status': 422,
                 'title': 'Unprocessable Entity',

--- a/tests/all/integration/api/session/test_session_forms_api.py
+++ b/tests/all/integration/api/session/test_session_forms_api.py
@@ -115,7 +115,7 @@ def test_edit_session_required_fields_missing(db, client, user, jwt):
     assert json.loads(response.data) == {
         'errors': [
             {
-                'detail': "Missing required fields ['level', 'short_abstract']",
+                'detail': "Missing required fields ['Level', 'Short Abstract']",
                 'source': {'pointer': '/data/attributes'},
                 'status': 422,
                 'title': 'Unprocessable Entity',
@@ -162,7 +162,7 @@ def test_create_session_required_fields_missing(db, client, user, jwt):
     assert json.loads(response.data) == {
         'errors': [
             {
-                'detail': "Missing required fields ['level', 'short_abstract']",
+                'detail': "Missing required fields ['Level', 'Short Abstract']",
                 'source': {'pointer': '/data/attributes'},
                 'status': 422,
                 'title': 'Unprocessable Entity',
@@ -328,7 +328,7 @@ def test_custom_form_complex_fields_missing_required(db, client, user, jwt):
     assert json.loads(response.data) == {
         'errors': [
             {
-                'detail': "Missing required fields ['Best Friend', 'Slides']",
+                'detail': "Missing required fields ['Best Friend', 'Slide']",
                 'source': {'pointer': '/data/attributes'},
                 'status': 422,
                 'title': 'Unprocessable Entity',
@@ -377,7 +377,7 @@ def test_custom_form_create_complex_fields_missing_required(db, client, user, jw
     assert json.loads(response.data) == {
         'errors': [
             {
-                'detail': "Missing required fields ['Best_friend', 'Slides']",
+                'detail': "Missing required fields ['Best Friend', 'Slide']",
                 'source': {'pointer': '/data/attributes'},
                 'status': 422,
                 'title': 'Unprocessable Entity',

--- a/tests/all/integration/api/speaker/test_speaker_api.py
+++ b/tests/all/integration/api/speaker/test_speaker_api.py
@@ -104,7 +104,7 @@ def test_edit_speaker_required_fields_missing(db, client, user, jwt):
     assert json.loads(response.data) == {
         'errors': [
             {
-                'detail': "Missing required fields ['mobile', 'speaking_experience']",
+                'detail': "Missing required fields ['mobile', 'Speaking Experience']",
                 'source': {'pointer': '/data/attributes'},
                 'status': 422,
                 'title': 'Unprocessable Entity',

--- a/tests/all/integration/api/speaker/test_speaker_api.py
+++ b/tests/all/integration/api/speaker/test_speaker_api.py
@@ -104,7 +104,7 @@ def test_edit_speaker_required_fields_missing(db, client, user, jwt):
     assert json.loads(response.data) == {
         'errors': [
             {
-                'detail': "Missing required fields ['mobile', 'Speaking Experience']",
+                'detail': "Missing required fields ['Mobile', 'Speaking Experience']",
                 'source': {'pointer': '/data/attributes'},
                 'status': 422,
                 'title': 'Unprocessable Entity',
@@ -146,7 +146,7 @@ def test_create_speaker_required_fields_missing(db, client, jwt):
     assert json.loads(response.data) == {
         'errors': [
             {
-                'detail': "Missing required fields ['mobile', 'speaking_experience']",
+                'detail': "Missing required fields ['Mobile', 'Speaking Experience']",
                 'source': {'pointer': '/data/attributes'},
                 'status': 422,
                 'title': 'Unprocessable Entity',

--- a/tests/all/integration/api/speaker/test_speaker_api.py
+++ b/tests/all/integration/api/speaker/test_speaker_api.py
@@ -292,7 +292,7 @@ def test_custom_form_complex_fields_missing_required(db, client, user, jwt):
     assert json.loads(response.data) == {
         'errors': [
             {
-                'detail': "Missing required fields ['best_friend', 'heard_from']",
+                'detail': "Missing required fields ['Best Friend', 'Heard From']",
                 'source': {'pointer': '/data/attributes'},
                 'status': 422,
                 'title': 'Unprocessable Entity',

--- a/tests/all/integration/api/speaker/test_speaker_api.py
+++ b/tests/all/integration/api/speaker/test_speaker_api.py
@@ -333,7 +333,7 @@ def test_custom_form_create_complex_fields_missing_required(db, client, jwt):
     assert json.loads(response.data) == {
         'errors': [
             {
-                'detail': "Missing required fields ['best_friend', 'heard_from']",
+                'detail': "Missing required fields ['Best Friend', 'Heard From']",
                 'source': {'pointer': '/data/attributes'},
                 'status': 422,
                 'title': 'Unprocessable Entity',


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes [#8878](https://github.com/fossasia/open-event-frontend/issues/8878)

#### Short description of what this resolves:
Can't read errors related to unfilled fields in the form

#### Changes proposed in this pull request:

-Can't read errors related to unfilled fields in the form

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.
