### PR TITLE
Fix missing migrations

### DIFF
--- a/migrations/versions/rev-2023-08-11-15:26:07-1af4cc4f7cd5_.py
+++ b/migrations/versions/rev-2023-08-11-15:26:07-1af4cc4f7cd5_.py
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '1af4cc4f7cd5'
-down_revision = '414c776ae509'
+down_revision = '24271525a263'
 
 
 def upgrade():

--- a/migrations/versions/rev-2024-03-21-1:15:00-was_before_2023-08-11-00:00:08-414c776ae509_.py
+++ b/migrations/versions/rev-2024-03-21-1:15:00-was_before_2023-08-11-00:00:08-414c776ae509_.py
@@ -1,8 +1,10 @@
 """empty message
 
 Revision ID: 414c776ae509
-Revises: 24271525a263
+Revises: bce7acfe5a4f
 Create Date: 2023-08-10 00:00:08.837497
+
+Moved to 2024-03-21 to fix missing application due to split head
 
 """
 
@@ -12,7 +14,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '414c776ae509'
-down_revision = '24271525a263'
+down_revision = 'bce7acfe5a4f'
 
 
 def upgrade():


### PR DESCRIPTION
The migration line was messed up in the commits aournd 2023-08-11 and 17.

As of now in the test installation, 414c776ae509 is NOT applied.

- adjust the `down_revision` of 1af4cc4f7cd5 from 414c776ae509 (incorrect, not applied) to 24271525a263
- move 414c776ae509 to 2024-03-21 and change down revision to bce7acfe5a4f, the current head of the migrations.