### PR TITLE
Changed method of  generation of passwords and added error handling, along with function return types.

### DIFF
--- a/app/api/chat/rocket_chat.py
+++ b/app/api/chat/rocket_chat.py
@@ -3,7 +3,7 @@ import string
 import secrets
 from dataclasses import dataclass
 from typing import Optional
-
+ 
 import requests
 
 from app.api.helpers.db import get_new_identifier, get_or_create


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #N/A

#### Short description of what this resolves:
Checks for negative length password, hence added error handling and added return types to all functions in ./app/api/chat/rocket_chat.py

#### Changes proposed in this pull request:
Used 'secrets' library instead of random , since it is cryptographically secure, added error handling to check for negative length of passwords. Also added return types of all the functions.

-
-
-

#### Checklist

- [ ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [ ✔️] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [✔️ ] All the functions created/modified in this PR contain relevant docstrings.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance password generation security by using the 'secrets' library and add error handling for invalid password parameters. Add return type annotations to all functions in app/api/chat/rocket_chat.py.

Enhancements:
- Switched password generation to use the 'secrets' library for cryptographic security.
- Added error handling for negative password lengths and empty password character sets.
- Added return type annotations to all functions in app/api/chat/rocket_chat.py.

<!-- Generated by sourcery-ai[bot]: end summary -->