### PR TITLE
Sanitized the user input before logging preventing log injection

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -50,7 +50,11 @@ logger = logging.getLogger(__name__)
 authorised_blueprint = Blueprint('authorised_blueprint', __name__, url_prefix='/')
 auth_routes = Blueprint('auth', __name__, url_prefix='/v1/auth')
 
-
+def sanitize(value):
+    if not isinstance(value, str):
+        return ''
+    return value.replace('\n', '\\n').replace('\r', '\\r')
+    
 def authenticate(allow_refresh_token=False, existing_identity=None):
     data = request.get_json()
     username = data.get('email', data.get('username'))
@@ -311,11 +315,7 @@ def verify_email():
 
 @auth_routes.route('/resend-verification-email', methods=['POST'])
 def resend_verification_email():
-    def sanitize(value):
-    if not isinstance(value, str):
-        return ''
-    return value.replace('\n', '\\n').replace('\r', '\\r')
-
+    
 
     try:
         email = request.json['data']['email']

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -312,9 +312,10 @@ def verify_email():
 @auth_routes.route('/resend-verification-email', methods=['POST'])
 def resend_verification_email():
     def sanitize(value):
-        if not isinstance(value, str):
-             return ''
-        return value.replace('\n', '\\n').replace('\r', '\\r')
+    if not isinstance(value, str):
+        return ''
+    return value.replace('\n', '\\n').replace('\r', '\\r')
+
 
     try:
         email = request.json['data']['email']

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -311,6 +311,11 @@ def verify_email():
 
 @auth_routes.route('/resend-verification-email', methods=['POST'])
 def resend_verification_email():
+    def sanitize(value):
+        if not isinstance(value, str):
+             return ''
+        return value.replace('\n', '\\n').replace('\r', '\\r')
+
     try:
         email = request.json['data']['email']
     except TypeError:
@@ -320,13 +325,12 @@ def resend_verification_email():
     try:
         user = User.query.filter_by(email=email).one()
     except NoResultFound:
-        def sanitize(value):
-              return value.replace('\n', '\\n').replace('\r', '\\r')
+        
         safe_mail = sanitize(email)
-        logger.error("User with email: %s not found", safe_mail)
+        logging.error("User with email: %s not found", safe_mail)
 
         raise UnprocessableEntityError(
-            {'source': ''}, 'User with email: %s not found.'%safe_mail
+           {'source': ''}, f'User with email: {safe_mail} not found.'
         )
     else:
         serializer = get_serializer()

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -320,9 +320,13 @@ def resend_verification_email():
     try:
         user = User.query.filter_by(email=email).one()
     except NoResultFound:
-        logging.info('User with email: ' + email + ' not found.')
+        def sanitize(value):
+              return value.replace('\n', '\\n').replace('\r', '\\r')
+        safe_mail = sanitize(email)
+        logger.error("User with email: %s not found", safe_mail)
+
         raise UnprocessableEntityError(
-            {'source': ''}, 'User with email: ' + email + ' not found.'
+            {'source': ''}, 'User with email: %s not found.'%safe_mail
         )
     else:
         serializer = get_serializer()


### PR DESCRIPTION
Fixes #9120

Short description of what this resolves:
Resolves a potential log injection issue by sanitizing the input and switching to parameterized logging for user-provided email values in auth.

Changes proposed in this pull request:
Sanitized the email value before passing it into logging.error()
Replaced string concatenation with parameterized logging when logging user-provided email values in auth.py.
Eliminated a potential log injection risk by sanitizing user input and treating it as log parameters.


Checklist
[✅] I have read the Contribution & Best practices Guide and my PR follows them.
[✅] My branch is up-to-date with the Upstream development branch.
[✅] The unit tests pass locally with my changes
 I have added tests that prove my fix is effective or that my feature works
(Not applicable: This change only updates logging in auth.py to use parameterized logs. It does not modify functionality, so no dedicated test is required. All existing tests pass locally)
[✅]I have added necessary documentation (if appropriate)
[✅] All the functions created/modified in this PR contain relevant docstrings.

## Summary by Sourcery

Sanitize user-provided email values in the resend verification flow to prevent log injection in auth logging.

Bug Fixes:
- Prevent potential log injection by sanitizing user email before including it in log messages and user-facing error text.

Enhancements:
- Switch auth logging for missing users to parameterized logging instead of string concatenation for user-provided email values.