### PR TITLE
Thoroughly sanitized user input with a sanitize function and switched to parameterized logging for user-provided email values

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -328,7 +328,7 @@ def resend_verification_email():
     except NoResultFound:
         
         safe_mail = sanitize(email)
-        logging.error("User with email: %s not found", safe_mail)
+        logging.info("User with email: %s not found", safe_mail)
 
         raise UnprocessableEntityError(
            {'source': ''}, f'User with email: {safe_mail} not found.'

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -50,7 +50,11 @@ logger = logging.getLogger(__name__)
 authorised_blueprint = Blueprint('authorised_blueprint', __name__, url_prefix='/')
 auth_routes = Blueprint('auth', __name__, url_prefix='/v1/auth')
 
-
+def sanitize(value):
+    if not isinstance(value, str):
+        return ''
+    return value.replace('\n', '\\n').replace('\r', '\\r')
+    
 def authenticate(allow_refresh_token=False, existing_identity=None):
     data = request.get_json()
     username = data.get('email', data.get('username'))
@@ -311,11 +315,7 @@ def verify_email():
 
 @auth_routes.route('/resend-verification-email', methods=['POST'])
 def resend_verification_email():
-    def sanitize(value):
-    if not isinstance(value, str):
-        return ''
-    return value.replace('\n', '\\n').replace('\r', '\\r')
-
+    
 
     try:
         email = request.json['data']['email']

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -4,6 +4,8 @@ import random
 import string
 from datetime import timedelta
 from functools import wraps
+import re
+import unicodedata
 
 import requests
 from flask import Blueprint, jsonify, make_response, request, send_file
@@ -49,12 +51,28 @@ from app.models.user import User
 logger = logging.getLogger(__name__)
 authorised_blueprint = Blueprint('authorised_blueprint', __name__, url_prefix='/')
 auth_routes = Blueprint('auth', __name__, url_prefix='/v1/auth')
-
-def sanitize(value):
-    if not isinstance(value, str):
+ANSI_ESCAPE = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
+CONTROL_CHARS = re.compile(r'[\x00-\x1F\x7F]')
+def sanitize(value:str,max_length:int=512)->str:
+    #Sanitizes input to prevent log injection
+    if value is None:
         return ''
-    return value.replace('\n', '\\n').replace('\r', '\\r').replace('\t','\\t').replace('\u2028','\\u2028').replace('\u2029','\\u2029')
-    
+    # ensure entered value is string type
+    value=str(value)
+    # unicode normalization of value (prevention against homoglyph tricks)
+    value = unicodedata.normalize("NFKC", value)
+     # Remove Unicode line/paragraph separators
+    value = value.replace("\u2028", "\\u2028").replace("\u2029", "\\u2029")
+    # Remove CR/LF (classic log forging)
+    value = value.replace("\r", "\\r").replace("\n", "\\n")
+    # Remove ANSI escape sequences (terminal injection)
+    value = ANSI_ESCAPE.sub("", value)
+    # Remove remaining ASCII control characters
+    value = CONTROL_CHARS.sub("", value)
+    # Enforce max length (log flooding protection)
+    if len(value) > max_length:
+        value = value[:max_length] + "...[truncated]"
+    return value 
 def authenticate(allow_refresh_token=False, existing_identity=None):
     data = request.get_json()
     username = data.get('email', data.get('username'))
@@ -315,8 +333,6 @@ def verify_email():
 
 @auth_routes.route('/resend-verification-email', methods=['POST'])
 def resend_verification_email():
-    
-
     try:
         email = request.json['data']['email']
     except TypeError:
@@ -325,8 +341,7 @@ def resend_verification_email():
 
     try:
         user = User.query.filter_by(email=email).one()
-    except NoResultFound:
-        
+    except NoResultFound: 
         safe_mail = sanitize(email)
         logging.info("User with email: %s not found", safe_mail)
 

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -346,7 +346,7 @@ def resend_verification_email():
         logging.info("User with email: %s not found", safe_mail)
 
         raise UnprocessableEntityError(
-           {'source': ''}, f'User with email: {safe_mail} not found.'
+           {'source': ''}, f'User with email: {email} not found.'
         )
     else:
         serializer = get_serializer()

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -312,9 +312,10 @@ def verify_email():
 @auth_routes.route('/resend-verification-email', methods=['POST'])
 def resend_verification_email():
     def sanitize(value):
-        if not isinstance(value, str):
-             return ''
-        return value.replace('\n', '\\n').replace('\r', '\\r')
+    if not isinstance(value, str):
+        return ''
+    return value.replace('\n', '\\n').replace('\r', '\\r')
+
 
     try:
         email = request.json['data']['email']

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -311,6 +311,11 @@ def verify_email():
 
 @auth_routes.route('/resend-verification-email', methods=['POST'])
 def resend_verification_email():
+    def sanitize(value):
+        if not isinstance(value, str):
+             return ''
+        return value.replace('\n', '\\n').replace('\r', '\\r')
+
     try:
         email = request.json['data']['email']
     except TypeError:
@@ -320,13 +325,12 @@ def resend_verification_email():
     try:
         user = User.query.filter_by(email=email).one()
     except NoResultFound:
-        def sanitize(value):
-              return value.replace('\n', '\\n').replace('\r', '\\r')
+        
         safe_mail = sanitize(email)
-        logger.error("User with email: %s not found", safe_mail)
+        logging.error("User with email: %s not found", safe_mail)
 
         raise UnprocessableEntityError(
-            {'source': ''}, 'User with email: %s not found.'%safe_mail
+           {'source': ''}, f'User with email: {safe_mail} not found.'
         )
     else:
         serializer = get_serializer()

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -320,9 +320,13 @@ def resend_verification_email():
     try:
         user = User.query.filter_by(email=email).one()
     except NoResultFound:
-        logging.info('User with email: ' + email + ' not found.')
+        def sanitize(value):
+              return value.replace('\n', '\\n').replace('\r', '\\r')
+        safe_mail = sanitize(email)
+        logger.error("User with email: %s not found", safe_mail)
+
         raise UnprocessableEntityError(
-            {'source': ''}, 'User with email: ' + email + ' not found.'
+            {'source': ''}, 'User with email: %s not found.'%safe_mail
         )
     else:
         serializer = get_serializer()

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -53,7 +53,7 @@ auth_routes = Blueprint('auth', __name__, url_prefix='/v1/auth')
 def sanitize(value):
     if not isinstance(value, str):
         return ''
-    return value.replace('\n', '\\n').replace('\r', '\\r')
+    return value.replace('\n', '\\n').replace('\r', '\\r').replace('\t','\\t).replace('\u2028','\\u2028).replace('\u2029','\\u2028)
     
 def authenticate(allow_refresh_token=False, existing_identity=None):
     data = request.get_json()

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -53,7 +53,7 @@ auth_routes = Blueprint('auth', __name__, url_prefix='/v1/auth')
 def sanitize(value):
     if not isinstance(value, str):
         return ''
-    return value.replace('\n', '\\n').replace('\r', '\\r').replace('\t','\\t).replace('\u2028','\\u2028).replace('\u2029','\\u2028)
+    return value.replace('\n', '\\n').replace('\r', '\\r').replace('\t','\\t').replace('\u2028','\\u2028').replace('\u2029','\\u2029')
     
 def authenticate(allow_refresh_token=False, existing_identity=None):
     data = request.get_json()


### PR DESCRIPTION
Fixes #9120

Short description of what this resolves:
Resolves a potential log injection issue by sanitizing the input and switching to parameterized logging for user-provided email values in auth.

Changes proposed in this pull request:
Sanitized the email value before passing it into logging.error()
Replaced string concatenation with parameterized logging when logging user-provided email values in auth.py.
Eliminated a potential log injection risk by sanitizing user input and treating it as log parameters.


Checklist
[✅] I have read the Contribution & Best practices Guide and my PR follows them.
[✅] My branch is up-to-date with the Upstream development branch.
[✅] The unit tests pass locally with my changes
 I have added tests that prove my fix is effective or that my feature works
(Not applicable: This change only updates logging in auth.py . It does not modify functionality, so no dedicated test is required. All existing tests pass locally)
[✅]I have added necessary documentation (if appropriate)
[✅] All the functions created/modified in this PR contain relevant docstrings.

Why this PR supersedes PR #9147:
PR #9147 only handled the cases where the malicious injection contained only \t, \n, or \r, but this PR handles a much broader set of attack vectors, including Unicode homoglyph tricks via NFKC normalization, Unicode line and paragraph separators (\u2028, \u2029), ANSI escape sequences used for terminal injection, remaining ASCII control characters, and log flooding through enforced maximum length limits.

## Summary by Sourcery

Harden auth logging against log injection by sanitizing user-provided values and using parameterized logging for email-related messages.

Enhancements:
- Introduce a reusable sanitize helper to normalize and scrub potentially dangerous characters from user-provided values before logging.
- Update auth email not-found logging to use sanitized, parameterized log messages instead of string concatenation.