### PR TITLE
Fix: Prevent payment before approval for approval-required tickets

### DIFF
--- a/app/api/data_layers/ChargesLayer.py
+++ b/app/api/data_layers/ChargesLayer.py
@@ -42,7 +42,7 @@ class ChargesLayer(BaseDataLayer):
                 "You cannot charge payments on a cancelled, expired or completed order",
             )
         # BLOCK PAYMENT BEFORE ORGANISER APPROVAL
-    if order.require_approval and order.status == 'pending':
+    if order.require_approval and not order.is_approved:
             raise ConflictError(
                 {'parameter': 'id'},
             "This order requires organiser approval before payment",

--- a/app/api/data_layers/ChargesLayer.py
+++ b/app/api/data_layers/ChargesLayer.py
@@ -41,6 +41,13 @@ class ChargesLayer(BaseDataLayer):
                 {'parameter': 'id'},
                 "You cannot charge payments on a cancelled, expired or completed order",
             )
+		# BLOCK PAYMENT BEFORE ORGANISER APPROVAL
+	if order.require_approval and order.status == 'pending':
+    		raise ConflictError(
+       		 {'parameter': 'id'},
+        	"This order requires organiser approval before payment",
+   		 )
+
         if (not order.amount) or order.amount == 0:
             raise ConflictError(
                 {'parameter': 'id'}, "You cannot charge payments on a free order"

--- a/app/api/data_layers/ChargesLayer.py
+++ b/app/api/data_layers/ChargesLayer.py
@@ -41,12 +41,12 @@ class ChargesLayer(BaseDataLayer):
                 {'parameter': 'id'},
                 "You cannot charge payments on a cancelled, expired or completed order",
             )
-		# BLOCK PAYMENT BEFORE ORGANISER APPROVAL
-	if order.require_approval and order.status == 'pending':
-    		raise ConflictError(
-       		 {'parameter': 'id'},
-        	"This order requires organiser approval before payment",
-   		 )
+        # BLOCK PAYMENT BEFORE ORGANISER APPROVAL
+    if order.require_approval and order.status == 'pending':
+            raise ConflictError(
+                {'parameter': 'id'},
+            "This order requires organiser approval before payment",
+            )
 
         if (not order.amount) or order.amount == 0:
             raise ConflictError(

--- a/app/api/data_layers/ChargesLayer.py
+++ b/app/api/data_layers/ChargesLayer.py
@@ -1,4 +1,3 @@
-
 from flask_rest_jsonapi.data_layers.base import BaseDataLayer
 from flask_rest_jsonapi.exceptions import ObjectNotFound
 
@@ -43,10 +42,10 @@ class ChargesLayer(BaseDataLayer):
                 "You cannot charge payments on a cancelled, expired or completed order",
             )
         # BLOCK PAYMENT BEFORE ORGANISER APPROVAL
-   	 if order.require_approval and order.status == Order.STATUS_PENDING:
-           	 raise ConflictError(
-                	{'parameter': 'id'},
-            		"This order requires organiser approval before payment",
+        if order.require_approval and order.status == Order.STATUS_PENDING:
+            raise ConflictError(
+                {'parameter': 'id'},
+                "This order requires organiser approval before payment",
             )
 
         if (not order.amount) or order.amount == 0:

--- a/app/api/data_layers/ChargesLayer.py
+++ b/app/api/data_layers/ChargesLayer.py
@@ -1,3 +1,4 @@
+
 from flask_rest_jsonapi.data_layers.base import BaseDataLayer
 from flask_rest_jsonapi.exceptions import ObjectNotFound
 
@@ -42,10 +43,10 @@ class ChargesLayer(BaseDataLayer):
                 "You cannot charge payments on a cancelled, expired or completed order",
             )
         # BLOCK PAYMENT BEFORE ORGANISER APPROVAL
-    if order.require_approval and not order.is_approved:
-            raise ConflictError(
-                {'parameter': 'id'},
-            "This order requires organiser approval before payment",
+   	 if order.require_approval and order.status == Order.STATUS_PENDING:
+           	 raise ConflictError(
+                	{'parameter': 'id'},
+            		"This order requires organiser approval before payment",
             )
 
         if (not order.amount) or order.amount == 0:

--- a/app/api/data_layers/ChargesLayer.py
+++ b/app/api/data_layers/ChargesLayer.py
@@ -7,13 +7,15 @@ from app.models.order import Order
 
 
 class ChargesLayer(BaseDataLayer):
-    def _ensure_order_is_approvable(self, order):
+    @staticmethod
+    def _ensure_order_is_approvable(order):
         """Prevent payment only when order is waiting for organiser approval"""
         if order.require_approval and order.status == Order.STATUS_PENDING:
             raise ConflictError(
                 {'parameter': 'id'},
                 "This order requires organiser approval before payment",
             )
+
 
     def create_object(self, data, view_kwargs):
         """
@@ -54,12 +56,6 @@ class ChargesLayer(BaseDataLayer):
             )
         # prevent payment before organiser approval
         self._ensure_order_is_approvable(order)
-        # # BLOCK PAYMENT BEFORE ORGANISER APPROVAL
-        # if order.require_approval and order.status == Order.STATUS_PENDING:
-        #     raise ConflictError(
-        #         {'parameter': 'id'},
-        #         "This order requires organiser approval before payment",
-        #     )
 
         if (not order.amount) or order.amount == 0:
             raise ConflictError(

--- a/app/api/data_layers/ChargesLayer.py
+++ b/app/api/data_layers/ChargesLayer.py
@@ -7,6 +7,14 @@ from app.models.order import Order
 
 
 class ChargesLayer(BaseDataLayer):
+    def _ensure_order_is_approvable(self, order):
+        """Prevent payment only when order is waiting for organiser approval"""
+        if order.require_approval and order.status == Order.STATUS_PENDING:
+            raise ConflictError(
+                {'parameter': 'id'},
+                "This order requires organiser approval before payment",
+            )
+
     def create_object(self, data, view_kwargs):
         """
         create_object method for the Charges layer
@@ -32,6 +40,9 @@ class ChargesLayer(BaseDataLayer):
                     view_kwargs['order_identifier']
                 ),
             )
+        # # prevent payment before organiser approval
+        # self._ensure_order_is_approvable(order)
+
         if (
             order.status == 'cancelled'
             or order.status == 'expired'
@@ -41,12 +52,14 @@ class ChargesLayer(BaseDataLayer):
                 {'parameter': 'id'},
                 "You cannot charge payments on a cancelled, expired or completed order",
             )
-        # BLOCK PAYMENT BEFORE ORGANISER APPROVAL
-        if order.require_approval and order.status == Order.STATUS_PENDING:
-            raise ConflictError(
-                {'parameter': 'id'},
-                "This order requires organiser approval before payment",
-            )
+        # prevent payment before organiser approval
+        self._ensure_order_is_approvable(order)
+        # # BLOCK PAYMENT BEFORE ORGANISER APPROVAL
+        # if order.require_approval and order.status == Order.STATUS_PENDING:
+        #     raise ConflictError(
+        #         {'parameter': 'id'},
+        #         "This order requires organiser approval before payment",
+        #     )
 
         if (not order.amount) or order.amount == 0:
             raise ConflictError(


### PR DESCRIPTION
Fixes fossasia/eventyay#2364

## Problem
Orders containing products with `require_approval=True` could still proceed to payment because payment creation was not strictly blocked by order state.

## Solution
This patch enforces the approval workflow by:

- Forcing approval-required orders into `pending` state at creation
- Preventing automatic payment creation during order creation
- Blocking payment API while the order is still pending approval
- Allowing payment only after organiser approval

## Result
Approval tickets now correctly follow:

pending → organiser approval → payment → completed

Normal tickets remain unaffected.

## Summary by Sourcery

Enforce the approval workflow so that orders requiring organiser approval cannot proceed to payment until they are approved.

Bug Fixes:
- Ensure orders containing approval-required tickets are created in a pending state and cannot automatically create payments.
- Block payment processing for pending approval-required orders, allowing payment only after organiser approval.