### PR TITLE
Add test case for expire_pending_tickets with no orders

### DIFF
--- a/tests/all/integration/api/helpers/test_scheduled_jobs.py
+++ b/tests/all/integration/api/helpers/test_scheduled_jobs.py
@@ -19,7 +19,7 @@ from tests.factories.attendee import AttendeeOrderSubFactory, AttendeeSubFactory
 from tests.factories.order import OrderSubFactory
 from tests.factories.ticket_fee import TicketFeesFactory
 from tests.factories.user import UserFactory
-from app.models import Order
+from app.models.order import Order
 
 
 def test_delete_ticket_holder_created_currently(db):

--- a/tests/all/integration/api/helpers/test_scheduled_jobs.py
+++ b/tests/all/integration/api/helpers/test_scheduled_jobs.py
@@ -122,6 +122,9 @@ def test_expire_pending_tickets(db):
 def test_expire_pending_tickets_no_orders(db):
     """Ensure no error when no pending orders exist"""
 
+    initial_count = Order.query.count()
+    assert initial_count == 0
+
     expire_pending_tickets()
 
-    assert Order.query.count() == 0
+    assert Order.query.count() == initial_count

--- a/tests/all/integration/api/helpers/test_scheduled_jobs.py
+++ b/tests/all/integration/api/helpers/test_scheduled_jobs.py
@@ -19,6 +19,7 @@ from tests.factories.attendee import AttendeeOrderSubFactory, AttendeeSubFactory
 from tests.factories.order import OrderSubFactory
 from tests.factories.ticket_fee import TicketFeesFactory
 from tests.factories.user import UserFactory
+from app.models import Order
 
 
 def test_delete_ticket_holder_created_currently(db):
@@ -118,3 +119,9 @@ def test_expire_pending_tickets(db):
     assert len(order_old.ticket_holders) == 3
     assert order_new.status == 'pending'
     assert len(order_new.ticket_holders) == 2
+def test_expire_pending_tickets_no_orders(db):
+    """Ensure no error when no pending orders exist"""
+
+    expire_pending_tickets()
+
+    assert Order.query.count() == 0


### PR DESCRIPTION
### Short description
This PR adds a test case for `expire_pending_tickets` when no orders exist.

### What this does
- Ensures the function runs without errors when there are no pending orders
- Improves test coverage for edge cases

### Changes made
- Added a new test function `test_expire_pending_tickets_no_orders`

### Notes
- No existing functionality was modified
- This is a safe test-only improvement

## Summary by Sourcery

Tests:
- Add an integration test verifying expire_pending_tickets runs without errors when there are no orders and leaves the orders table empty.